### PR TITLE
Updated reference: needed_improperids -> self.needed_improperids

### DIFF
--- a/moltemplate/ltemplify.py
+++ b/moltemplate/ltemplify.py
@@ -3898,7 +3898,7 @@ class Ltemplify(object):
                 if ((self.max_needed_impropertype == None) or
                     (self.max_needed_impropertype < impropertype)):
                     self.max_needed_impropertype = impropertype
-            for improperid in needed_improperids:
+            for improperid in self.needed_improperids:
                 assert(type(improperid) is int)
                 if ((self.min_needed_improperid == None) or
                     (self.min_needed_improperid > improperid)):


### PR DESCRIPTION
This pull request closes issue #20 

I'm not sure if pull requests from "unknown users" are encouraged in this repo, but in any case, I got the following error message while running ``ltemplify.py`` on a system with improper dihedrals:

```bash
File "ltemplify.py", line 3901, in PostProcess3
    for improperid in needed_improperids:
NameError: name 'needed_improperids' is not defined
```

It looks like it can be amended by referring to ``self.needed_improperids`` rather than just ``needed_improperids``. This pull request introduces this change and closes issue #20 