### PR TITLE
fix closing file if we're not the owner

### DIFF
--- a/moltemplate/ltemplify.py
+++ b/moltemplate/ltemplify.py
@@ -4685,7 +4685,7 @@ class Ltemplify(object):
         ########################################
         """
 
-        out_fname = ''
+        out_fname = None
         if isinstance(out_file, str):  # is "out_file" a file or a file name?
             out_fname = out_file
             out_file = open(out_fname, 'w')


### PR DESCRIPTION
The check in line 5215 does not work as is, proposing to fix the default-value for `out_fname` to match the check.