### PR TITLE
 Fixing attribute double initialization. 

### DIFF
--- a/moltemplate/genpoly_lt.py
+++ b/moltemplate/genpoly_lt.py
@@ -427,8 +427,6 @@ class GenPoly(object):
             infile = open(self.settings.infile_name, 'r')
             self.coords_multi = self.ReadCoords(infile)
             infile.close()
-        else:
-            self.coords_multi = []
 
         if ((len(self.settings.reverse_polymer_directions) != 0) and 
             (len(self.settings.reverse_polymer_directions) !=


### PR DESCRIPTION
self.coords_multi the value is already properly initialized in the constructor, its use in this part seems to prevent manual assignment by the client of the class.