### PR TITLE
DREIDING Hbonding Missing Interaction Fix

### DIFF
--- a/moltemplate/force_fields/dreiding.lt
+++ b/moltemplate/force_fields/dreiding.lt
@@ -29,11 +29,11 @@ DREIDING {
     angle_style     harmonic
     dihedral_style  charmm
     improper_style  umbrella
-    special_bonds   dreiding
+	special_bonds   dreiding	
 
-    # Coefficients in non-bonding are just as an example
-    pair_style hybrid/overlay lj/cut/coul/long 10.0 hbond/dreiding/lj 4 6 6.5 90
-    kspace_style    ewald 0.0001
+	# Coefficients in non-bonding are just as an example
+    pair_style      hybrid/overlay hbond/dreiding/lj 4 6 6.5 90 lj/cut/coul/long 10.0
+	kspace_style	ewald 0.0001
 
     dielectric      1.0
    
@@ -682,6 +682,7 @@ DREIDING {
 	pair_coeff  @atom:C_31  @atom:C_32 lj/cut/coul/long 0.1706027 3.5861795
 	pair_coeff  @atom:C_31  @atom:C_31 lj/cut/coul/long 0.1467 3.54845
 	pair_coeff  @atom:*_hd  @atom:*_hd hbond/dreiding/lj @atom:H_HB i 4.0 2.75 4
+	pair_coeff  @atom:*_hd  @atom:*_hd hbond/dreiding/lj @atom:H_HB j 4.0 2.75 4
 	pair_coeff  @atom:*_hd  @atom:*_ha hbond/dreiding/lj @atom:H_HB i 4.0 2.75 4
   } # End of 2-body (non-bonded) interactions
 
@@ -38296,18 +38297,3 @@ DREIDING {
 
 }  # DREIDING
 
-
-
-
-
-
-# OPTIONAL:
-# Generate a file ("log.cite.dreiding") containing a link to
-# a paper describing the DREIDING force field.
-
-write_once("log.cite.dreiding") {
-  "DREIDING: a generic force field for molecular simulations"
-  S.L. Mayo, B.D. Olafson, and W.A. Goddard,
-  J. Phys. Chem. 1990, 94, 26, 8897-8909
-  https://doi.org/10.1021/j100389a010
-}

--- a/moltemplate/force_fields/dreiding.lt
+++ b/moltemplate/force_fields/dreiding.lt
@@ -29,11 +29,11 @@ DREIDING {
     angle_style     harmonic
     dihedral_style  charmm
     improper_style  umbrella
-	special_bonds   dreiding	
+    special_bonds   dreiding
 
-	# Coefficients in non-bonding are just as an example
+    # Coefficients in non-bonding are just as an example
     pair_style      hybrid/overlay hbond/dreiding/lj 4 6 6.5 90 lj/cut/coul/long 10.0
-	kspace_style	ewald 0.0001
+    kspace_style	ewald 0.0001
 
     dielectric      1.0
    
@@ -38297,3 +38297,18 @@ DREIDING {
 
 }  # DREIDING
 
+
+
+
+
+
+# OPTIONAL:
+# Generate a file ("log.cite.dreiding") containing a link to
+# a paper describing the DREIDING force field.
+
+write_once("log.cite.dreiding") {
+  "DREIDING: a generic force field for molecular simulations"
+  S.L. Mayo, B.D. Olafson, and W.A. Goddard,
+  J. Phys. Chem. 1990, 94, 26, 8897-8909
+  https://doi.org/10.1021/j100389a010
+}


### PR DESCRIPTION
DREIDING requires two pair_coeffs for donor hydrogen bond interactions
The forcefield file now achieves this with an additional line
Previous simulations run with the force field will have lower than expected non-bonding potentials if modelling hydrogen bond donor pairs. 