### PR TITLE
Revert the name of the execution script to OUT_FILE_INPUT_SCRIPT

### DIFF
--- a/doc/moltemplate_manual_src/moltemplate_manual.tex
+++ b/doc/moltemplate_manual_src/moltemplate_manual.tex
@@ -1247,10 +1247,12 @@ Read all of the atomic coordinates from an external PDB file
 -dump coords.lammpstrj
 &
 Read all of the atomic coordinates from a LAMMPS dump (trajectory) file.
-(If ellipsoids are present, the dump file must be formatted in the
-following order:  ``id type xu yu zu c\_q[1] c\_q[2] c\_q[3] c\_q[4] ... ``
-where ``q'' is defined by
-``compute q all property/atom quatw quati quatj quatk''.)
+If ellipsoids are present, the dump file must also contain the quaterions
+printed  from one of the following computes:
+``compute q all property/atom quatw quati quatj quatk''
+``compute orient all property/atom quati quatj quatk quatw''.
+The parser also accepts DUMP headers with edited quaterion names
+such as qi, qj, qk, qw and quati, quatj, quatk, quatw.
 \\
 \hline
 -a '\textit{variable} \textit{value}'
@@ -1364,24 +1366,41 @@ Helpful additional post-processing for users of the \textbf{MOLC}
 coarse-grained model
 \\
 \hline
-\begin{tabular}[t]{l}
--short-comment-names
-\\
--full-comment-names
-\end{tabular}
-&
-Moltemplate writes atom type names in the comments following
-the ``Masses'' section of a LAMMPS data file.
-These two arguments control whether or not the \textit{short}
-or \textit{full} versions of the atom type names are printed there.
-(Default: short. See section \ref{sec:full_names} for details.)
-\\
-\hline
+%\begin{tabular}[t]{l}
+%-short-comment-names
+%\\
+%-full-comment-names
+%\end{tabular}
+%&
+%Moltemplate writes atom type names in the comments following
+%the ``Masses'' section of a LAMMPS data file.
+%These two arguments control whether or not the \textit{short}
+%or \textit{full} versions of the atom type names are printed there.
+%(Default: short. See section \ref{sec:full_names} for details.)
+%\\
+%\hline
 -forbid-wildcards &
 Forbid the use of ``*'' and ``?'' characters in
 ``pair\_coeff'', ``bond\_coeff'', ``angle\_coeff'', ``dihedral\_coeff'',
 and ``improper\_coeff'' commands.  (eg: ``bond\_coeff @bond:CH?? ...'', ``pair\_coeff @atom:C* @atom:C* ...''.  These are allowed by default.)
 \\
+\hline
+-lammps-script basename &
+                By default, moltemplate.sh writes a LAMMPS execution script with
+		the same base name of the input LT file. If the LT file has the
+		special name "system.lt", then the LAMMPS execution script is
+		named run.in.EXAMPLE. This behaviour can be overwritten by
+		specifying a custom basename for the execution script. Note that
+		the INIT, DATA, SETTINGS, and RUN files will still have the same
+		basename of the parent LT file.
+\\
+\hline
+-run-example &
+    Append an example run section at the end of the example input
+                script. The commands are commented out and need manual editing
+		to get a meaningful simulation.
+\\
+\hline\hline
 \end{longtable}
 
 

--- a/doc/moltemplate_manual_src/moltemplate_manual.tex
+++ b/doc/moltemplate_manual_src/moltemplate_manual.tex
@@ -1302,6 +1302,8 @@ are non-exclusive.
 \\
 -overlay-impropers
 \\
+-overlay-all
+\\
 \end{tabular}
 & 
 By default moltemplate overwrites 
@@ -1310,9 +1312,12 @@ involve the same set of atoms.
 These flags disable that behavior.
 This can be useful when you want to superimpose 
 multiple angular or dihedral forces on the same set of atoms
-(eg. to enable more complex force fields).
+(e.g. to enable more complex force fields).
 Note: Each duplicate must still be given an unique
 \$bond, \$angle, \$dihedral, \$improper style variable name.
+These options also prevent reordering of atom indexes,
+e.g. by allowing to define a bond between
+atom 3 and 2 instead of 2 and 3.
 \\
 \hline
 -nocheck &

--- a/moltemplate/scripts/moltemplate.sh
+++ b/moltemplate/scripts/moltemplate.sh
@@ -856,8 +856,8 @@ if [ "$OUT_FILE_EXAMPLE_SCRIPT" == "" ]; then
     OUT_FILE_EXAMPLE_SCRIPT="run.in.EXAMPLE"  # default LAMMPS input script example
     if [ "$OUT_FILE_BASE" != "system" ]; then
         # For users who choose custom .LT file names,
-        # the files that moltemplate creates should have custom names also:
-        OUT_FILE_EXAMPLE_SCRIPT="run.in.EXAMPLE.${OUT_FILE_BASE}"
+        # the execution script should have the same custom name:
+        OUT_FILE_EXAMPLE_SCRIPT=$OUT_FILE_INPUT_SCRIPT
     fi
 fi
 

--- a/moltemplate/scripts/moltemplate.sh
+++ b/moltemplate/scripts/moltemplate.sh
@@ -355,11 +355,13 @@ Optional arguments:
                 3 or 4 consecutively bonded atoms in the system
                 (defined in "Angles/Dihedrals By Type").
 
--overlay-angles     Normally, moltemplate.sh checks to see if multiple angle
--overlay-dihedrals  interactions are defined for the same triplet of atoms.
--overlay-impropers  If so, it deletes the redundant ones (keeping the last one).
--overlay-bonds     (It does the same thing for bonds, dihedrals, and impropers.)
-                    Use these options to prevent that behavoir.
+-overlay-bonds      Normally, moltemplate.sh checks to see if multiple angle
+-overlay-angles     interactions are defined for the same triplet of atoms.
+-overlay-dihedrals  If so, it deletes the redundant ones (keeping the last one).
+-overlay-impropers  (It does the same thing for bonds, dihedrals, and impropers.)
+-overlay-all        Use these options to prevent that behavoir, or to prevent
+                    reordering of atom indexes, e.g. by allowing to define a bond
+                    between atom 3 and 2 instead of 2 and 3.
 
 -angle-symmetry file.py     Normally moltemplate.sh reorders the atoms in each
 -dihedral-symmetry file.py  angle, dihedral, improper, and bond interaction.
@@ -480,16 +482,16 @@ while [ "$i" -lt "$ARGC" ]; do
         fi
     elif [ "$A" = "-checkff" ]; then
         CHECKFF="$A"
-    elif [ "$A" = "-overlay-bonds" ]; then
+    elif [ "$A" = "-overlay-bonds" ] || [ "$A" = "-overlay-all" ]; then
         # In that case, do not remove duplicate bond interactions
         unset REMOVE_DUPLICATE_BONDS
-    elif [ "$A" = "-overlay-angles" ]; then
+    elif [ "$A" = "-overlay-angles" ] || [ "$A" = "-overlay-all" ]; then
         # In that case, do not remove duplicate angle interactions
         unset REMOVE_DUPLICATE_ANGLES
-    elif [ "$A" = "-overlay-dihedrals" ]; then
+    elif [ "$A" = "-overlay-dihedrals" ] || [ "$A" = "-overlay-all" ]; then
         # In that case, do not remove duplicate dihedral interactions
         unset REMOVE_DUPLICATE_DIHEDRALS
-    elif [ "$A" = "-overlay-impropers" ]; then
+    elif [ "$A" = "-overlay-impropers" ] || [ "$A" = "-overlay-all" ]; then
         # In that case, do not remove duplicate improper interactions
         unset REMOVE_DUPLICATE_IMPROPERS
     elif [ "$A" = "-vmd" ]; then

--- a/moltemplate/scripts/moltemplate.sh
+++ b/moltemplate/scripts/moltemplate.sh
@@ -324,7 +324,7 @@ Optional arguments:
 
 -raw raw_file   An optional file containing RAW atomic coordinates. RAW files are
                 simple 3-column ASCII files contain X Y Z coordinates for every
-		atom, separated by spaces.)
+		atom, separated by spaces.
 		
 
 -a "@atom:x 1"


### PR DESCRIPTION
When a user specifies a custom LT name to create the input deck for LAMMPS, the execution script should also inherit the same root, as it was up to the 24 Jun 22. This is a very trivial change. I hope it is in line with the intended use of Moltemplate.
Cheers!