### PR TITLE
adding a converter from OPLSSAA-2023 FF files

### DIFF
--- a/moltemplate/force_fields/convert_OPLSAA_to_LT/Jorgensen_et_al-2024-The_Journal_of_Physical_Chemistry_B.sup-2.txt
+++ b/moltemplate/force_fields/convert_OPLSAA_to_LT/Jorgensen_et_al-2024-The_Journal_of_Physical_Chemistry_B.sup-2.txt
@@ -1,0 +1,2421 @@
+ OPLS All-Atom Parameters for Organic Molecules, Ions, Peptides & Nucleic Acids: Oct  1, 2023       
+ TYP AN AT   CHARGE     SIGMA    EPSILON                                                            
+   1 01 H     0.000     2.460     0.030     Types 1-18, 35, 53 give generic L-J                     
+   2 02 He    0.000     2.556     0.020     parameters for QM/MM calculations.                      
+   3 03 Li    0.000     2.126     0.018     LJ params for H on heteroatom are set                   
+   4 04 Be    0.000     3.25      0.05      to zero by BOSS.                                        
+   5 05 B     0.000     3.60      0.05                                                              
+   6 06 C     0.000     3.550     0.068                                                             
+   7 07 N     0.000     3.250     0.170                                                             
+   8 08 O     0.000     3.000     0.170   
+   9 09 F     0.000     2.900     0.060  
+  10 10 Ne    0.000     2.780     0.069                                                             
+  11 11 Na    0.000     3.330     0.003                                                             
+  12 12 Mg    0.000     3.40      0.05                                                              
+  13 13 Al    0.000     4.05      0.10                                                              
+  14 14 Si    0.000     4.00      0.10                                                              
+  15 15 P     0.000     3.740     0.200                                                             
+  16 16 S     0.000     3.600     0.355                                                             
+  17 17 Cl    0.000     3.400     0.300                                                             
+  18 18 Ar    0.000     3.401     0.234                                                             
+  20 10 Ne    0.000     2.0       0.100     2-A probe                                               
+  35 35 Br    0.000     3.470     0.470                                                             
+  53 53 I     0.000     3.55      0.58                                                              
+#                                                                                                   
+#   This file contains the non-bonded and torsional parameters that have been                       
+#   published for the OPLS-AA force field and other unpublished parameters.                         
+#        W. L. Jorgensen, D. S. Maxwell, and J. Tirado-Rives,                                       
+#        J. Am. Chem. Soc. 118, 11225-11236 (1996).                                                 
+#                                                                                                   
+#        New Alkane Parameters - OPLS/2020  - also see 711-716                                        
+#        Ghahremanpour, M.; Tirado-Rives, J.; Jorgensen, W. L. 
+#        J. Phys. Chem. B 2022, 126, 5896-5907.
+  54 06 CT   -0.180     3.550     0.066     n-CH3   all-atom C: alkanes                             
+  55 06 CT   -0.180     3.400     0.072     iso-CH3 all-atom C: alkanes                             
+  56 06 CT   -0.180     3.340     0.070     neo-CH3 all-atom C: alkanes                             
+  57 06 CT   -0.120     3.510     0.066     CH2     all-atom C: alkanes                             
+  58 06 CT   -0.060     3.500     0.066     CH      all-atom C: alkanes                             
+  59 06 CT    0.00      3.500     0.066     C       all-atom C: alkanes                             
+  60 01 HC    0.060     2.480     0.026     H       all-atom H: alkanes                             
+  61 06 CT   -0.065     3.550     0.066     all-atom C: CH3, toluene                                
+  62 06 CT   -0.005     3.510     0.066     all-atom C: CH2, ethyl benzene                          
+  63 06 CT    0.055     3.500     0.066     all-atom C: CH,  i-propyl benzene                       
+  64 06 CT    0.115     3.500     0.066     all-atom C: C,   t-butyl benzene                        
+#                                          Types 66-134 include UA parameters for                      
+#                                          stored solvent models for BOSS and
+#                                          should not be removed.                                              
+  66 06 C4    0.0       3.730     0.294     CH4 66-77: JACS,106,6638 (1984)                         
+  67 06 C3    0.0       3.775     0.207     CH3 (C1) ETHANE                                         
+  68 06 C3    0.0       3.905     0.175     CH3 (C2) N-ALKANES                                      
+  69 06 C3    0.0       3.910     0.160     CH3 (C3) ISOBUTANE                                      
+  70 06 C3    0.0       3.960     0.145     CH3 (C4) NEOPENTANE                                     
+  71 06 C2    0.0       3.905     0.118     CH2 (SP3) ALKANES                                       
+  72 06 C9    0.0       3.850     0.140     CH2 (SP2) 1-ALKENES                                     
+  73 06 CH    0.0       3.850     0.080     CH  (SP3) ISOBUTANE                                     
+  74 06 C8    0.0       3.800     0.115     CH  (SP2) 2-ALKENES                                     
+  75 06 CD    0.0       3.750     0.110     CH (AROM) BENZENOID united atom                         
+  76 06 CT    0.0       3.800     0.050     C   (SP3) NEOPENTANE                                    
+  77 06 C7    0.0       3.750     0.105     C   (SP2) ISOBUTENE                                     
+  78 08 OH   -0.700     3.070     0.170     O   ALCOHOLS   JPC,90,1276 (1986)                       
+  79 01 HO    0.435     0.0       0.0       H(O) ALCOHOLS        "                                  
+  80 06 C3    0.265     3.775     0.207     CH3 IN METHANOL      "                                  
+  81 06 C2    0.265     3.905     0.118     CH2 IN ETHANOL       "                                  
+  82 16 SH   -0.470     3.700     0.250     S   IN H2S  JPC,90,6379 (1986)                          
+  83 16 SH   -0.450     3.550     0.250     S   IN RSH        "                                     
+  84 16 S    -0.470     3.550     0.250     S   IN RSR        "                                     
+  85 16 S    -0.300     3.550     0.250     S   IN RSSR       "                                     
+  86 01 HS    0.235     0.0       0.0       H   IN H2S        "                                     
+  87 01 HS    0.270     0.0       0.0       H(S) IN RSH       "                                     
+  88 06 C3    0.180     3.775     0.207     CH3 IN CH3SH      "                                     
+  89 06 C2    0.180     3.905     0.118     CH2 IN CH3CH2SH   "                                     
+  90 06 C3    0.235     3.800     0.170     CH3 IN CH3SR      "                                     
+  91 06 C2    0.235     3.800     0.118     CH2 IN RCH2SR     "                                     
+  92 06 C3    0.300     3.800     0.170     CH3 IN CH3SSR     "                                     
+  93 06 C2    0.300     3.800     0.118     CH2 IN RCH2SSR    "                                     
+  94 07 NZ   -0.430     3.200     0.170     N IN CH3CN  Mol.Phys.,63,547 (1988)                     
+  95 06 CZ    0.280     3.650     0.150     C IN CH3CN           "                                  
+  96 06 C3    0.150     3.775     0.207     CH3 IN CH3CN  united atom    "                          
+  97 08 OW    0.0       3.12      0.16      O TIP5P Water                                           
+  98 01 HW    0.241     0.0       0.0       H TIP5P Water                                           
+  99 02 LP   -0.241     0.0       0.0       M TIP5P Water                                           
+ 100 99 DM    0.0       0.0       0.0       DUMMY ATOM                                              
+ 101 02 He    0.000     2.556     0.020     Helium -     "          "                               
+ 102 10 Ne    0.0       2.780     0.069     Neon -  Hirschfelder (Wiley,1954)                       
+ 103 18 Ar    0.000     3.401     0.2339    Ar - Verlet & Weis,                                     
+ 104 36 Kr    0.000     3.624     0.3170    Kr - Mol.Phys.,24,1013 (1972)                           
+ 105 54 Xe    0.000     3.935     0.4330    Xe -           "                                        
+ 106 06 CH    0.265     3.850     0.080     CH  (SP3) ISOPROPANOL                                   
+ 107 06 CT    0.265     3.800     0.050     C   (SP3) T-BUTANOL                                     
+ 108 08 OS   -0.50      3.000     0.170     ETHER O  JCC,11,958 (1990) UA                           
+ 109 06 C3    0.25      3.800     0.170     ETHER CH3 (-O)   "                                      
+ 110 06 C2    0.25      3.800     0.118     ETHER CH2 (-O)   "                                      
+ 111 08 OW   -0.834     3.15061   0.1521    O TIP3P Water JCP,79,926 (1983)                         
+ 112 01 HW    0.417     0.0       0.0       H TIP3P Water      "                                    
+ 113 08 OW    0.0       3.15365   0.1550    O TIP4P Water      "                                    
+ 114 01 HW    0.520     0.0       0.0       H TIP4P Water      "                                    
+ 115 02 LP   -1.040     0.0       0.0       M TIP4P Water      "                                    
+ 116 08 OW   -0.822     3.1760    0.1500    O TIP3F Water flexible model,                           
+ 117 01 HW    0.411     0.0       0.0       H TIP3F Water unpublished                               
+ 118 06 C2    0.500     3.800     0.118     CH2 Methylenechloride  C-Cl=1.772                       
+ 119 17 Cl   -0.250     3.400     0.300     Cl  Methylenechloride  ClCCl = 111.8                    
+ 120 06 CH    0.420     3.800     0.080     CH  Chloroform JPC,94,1683 (1990)                       
+ 121 17 Cl   -0.140     3.470     0.300     Cl  Chloroform C-Cl=1.758 ClCCl = 111.3                 
+ 122 06 CT    0.248     3.800     0.050     C   CCl4                                                
+ 123 17 Cl   -0.062     3.470     0.266     Cl  CCl4                                                
+ 124 16 SZ    0.139     3.56      0.395     DMSO UA unpublished                                     
+ 125 08 OY   -0.459     2.93      0.280     DMSO                                                    
+ 126 06 C3    0.160     3.81      0.160     DMSO                                                    
+ 127 07 NT   -1.020     3.42      0.170     Ammonia - OPLS-AA                                       
+ 128 01 H     0.340     0.0       0.0       Ammonia                                                 
+ 129 08 O    -0.500     2.960     0.210     O in DMF - united atom                                  
+ 130 07 N    -0.570     3.250     0.170     N in DMF - united atom                                  
+ 131 06 C     0.500     3.800     0.115     C in C=O for UA formamide, DMF.                         
+ 132 06 C3    0.285     3.80      0.170     CH3 in HCON(CH3)2 DMF                                   
+ 133 08 OW   -0.820     3.16557   0.1554    O  SPC  Water                                           
+ 134 01 HW    0.410     0.0       0.0       H  SPC  Water  
+#             ALL-ATOM PARAMETERS below here         
+#             135 - 140 are old OPLS-AA alkane parameters
+ 135 06 CT   -0.18      3.500     0.066     CH3    all-atom C: alkanes                              
+ 136 06 CT   -0.12      3.500     0.066     CH2    all-atom C: alkanes                              
+ 137 06 CT   -0.06      3.500     0.066     CH     all-atom C: alkanes                              
+ 138 06 CT   -0.24      3.570     0.060     CH4    all-atom C: methane mod 1/2020                   
+ 139 06 CT    0.00      3.500     0.066     C      all-atom C: alkanes                              
+ 140 01 HC    0.06      2.500     0.030     H      all-atom H: alkanes                              
+ 141 06 CM    0.000     3.550     0.076     alkene C (R2-C=) all atom                               
+ 142 06 CM   -0.115     3.550     0.076     alkene C (RH-C=) all atom                               
+ 143 06 CM   -0.230     3.550     0.076     alkene C (H2-C=) all atom                               
+ 144 01 HC    0.115     2.420     0.030     alkene H (H-C=)  all atom                               
+#  145 06 CA   -0.115     3.550     0.070     Benzene C - 12 site JACS,112,4768-90                  
+ 145 06 CA   -0.115     3.550     0.068     Benzene C - 12 site   OPLS/2020                         
+ 146 01 HA    0.115     2.420     0.030     Benzene H - 12 site        "                            
+ 147 06 CB    0.000     3.550     0.068     Naphthalene fusion C (C9)                               
+ 148 06 CT   -0.065     3.500     0.066     all-atom C: CH3, toluene                                
+ 149 06 CT   -0.005     3.500     0.066     all-atom C: CH2, ethyl benzene                          
+ 150 06 C=   -0.115     3.550     0.076     diene =CH-CH=; see 178 also                             
+ 151 17 Cl   -0.200     3.400     0.300     Cl in alkyl chlorides JPCB 16264 (2004)                 
+ 152 06 CT   -0.006     3.500     0.066     RCH2Cl "     "                                          
+ 153 01 HC    0.103     2.500     0.030     H in RCH2Cl                                             
+ 154 08 OH   -0.683     3.120     0.170     all-atom O: mono alcohols                               
+ 155 01 HO    0.418     0.0       0.0       all-atom H(O): mono alcohols                            
+ 156 01 HC    0.040     2.500     0.030     all-atom H(C): methanol                                 
+ 157 06 CT    0.145     3.500     0.066     all-atom C: CH3 & CH2, prim. alcohols                   
+ 158 06 CT    0.205     3.500     0.066     all-atom C: CH, sec. alcohols                           
+ 159 06 CT    0.232     3.500     0.066     all-atom C: C, tert. alcohols      OPLS/2020            
+ 160 08 OH   -0.650     3.150     0.170     all-atom O: mono tert. alcohols    OPLS/2020            
+ 161                                                                                                
+ 162                                                                                                
+ 163                                                                                                
+ 164                                                                                                
+ 165 06 CA    0.000     3.550     0.068     Cipso in styrene                                        
+ 166 06 CA    0.100     3.550     0.068     C(OH)  phenol  Use with all                             
+ 167 08 OH   -0.530     3.070     0.170     O      phenol  atom C, H                                
+ 168 01 HO    0.430     0.0       0.0       H      phenol  145 & 146                                
+ 169 08 OH   -0.700     3.070     0.170     O:    diols                                             
+ 170 01 HO    0.435     0.0       0.0       H(O): diols                                             
+ 171 08 OH   -0.730     3.070     0.170     O:    triols                                            
+ 172 01 HO    0.465     0.0       0.0       H(O): triols                                            
+ 173 06 CT    0.145     3.510     0.066     C(H2OH): diols, triols                                  
+ 174 06 CT    0.205     3.500     0.066     C(HROH):   "                                            
+ 175 06 CT    0.265     3.500     0.066     C(R2OH):   "                                            
+ 176 01 HC    0.060     2.480     0.026     H(CXOH):   "         OPLS/2020                          
+ 177 08 OS   -0.170     2.900     0.140     diphenyl ether       OPLS/2020                          
+ 178 06 C=    0.000     3.550     0.076     diene =CR-RC=; see 150 also                             
+ 179 08 OS   -0.285     2.900     0.140     O: anisole           OPLS/2020                          
+ 180 08 OS   -0.400     2.900     0.120     O: dialkyl ether     OPLS/2020                          
+ 181 06 CT    0.110     3.500     0.066     C(H3OR): methyl ether                                   
+ 182 06 CT    0.140     3.500     0.066     C(H2OR): ethyl  ether                                   
+ 183 06 CT    0.170     3.500     0.066     C(HOR):  i-Pr   ether                                   
+ 184 06 CT    0.200     3.500     0.066     C(OR):   t-Bu   ether                                   
+ 185 01 HC    0.030     2.480     0.026     H(COR): alpha H ether OPLS/2020 see 794                 
+ 186 08 OS   -0.330     2.900     0.140     O: acetal/hemiacetal ether O    OPLS/2020
+ 187 08 OH   -0.700     3.070     0.170     O(H): hemiacetal                                        
+ 188 01 HO    0.435     0.0       0.0       H(O): hemiacetal                                        
+ 189 06 CO    0.060     3.500     0.066     C(H2O2): acetal OCH2O                                   
+ 190 01 HC    0.100     2.500     0.030     H(CHO2): acetal OCH2O                                   
+ 191 06 CO    0.195     3.500     0.066     C(H2O2): hemiacetal OCH2OH                              
+ 192 01 HC    0.100     2.500     0.030     H(CHO2): hemiacetal OCH2OH                              
+ 193 06 CO    0.160     3.500     0.066     C(HCO2): acetal OCHRO                                   
+ 194 01 HC    0.100     2.500     0.030     H(CHO2): acetal OCHRO                                   
+ 195 06 CO    0.295     3.500     0.066     C(HCO2): hemiacetal OCHROH                              
+ 196 01 HC    0.100     2.500     0.030     H(C2O2): hemiacetal OCHROH                              
+ 197 06 CO    0.260     3.500     0.066     C(C2O2): acetal OCRRO                                   
+ 198 06 CO    0.395     3.500     0.066     C(C2O2): hemiacetal OCRROH                              
+ 199 06 CA    0.085     3.550     0.068     C(OMe)  anisole    OPLS/2020                            
+ 200 16 SH   -0.335     3.600     0.425     all-atom S: OPLS-AA/L (JPC B 2001, 105, 6474)           
+ 201 16 SH   -0.470     3.700     0.250     S   IN H2S  JPC,90,6379 (1986)                          
+ 202 16 S    -0.335     3.600     0.355     all-atom S: sulfides OPLS-AA/L                          
+ 203 16 S    -0.2175    3.600     0.355     all-atom S: disulfides OPLS-AA/L                        
+ 204 01 HS    0.155     0.0       0.0       all-atom H(S): thiols  (mod 11/99)                      
+ 205 01 HS    0.235     0.0       0.0       H   IN H2S  JPC,90,6379 (1986)                          
+ 206 06 CT    0.060     3.500     0.066     all-atom C: CH2, thiols                                 
+ 207 06 CT    0.120     3.500     0.066     all-atom C: CH, thiols                                  
+ 208 06 CT    0.180     3.500     0.066     all-atom C: C, thiols                                   
+ 209 06 CT   -0.0125    3.500     0.066     all-atom C: CH3, sulfides OPLS-AA/L                     
+ 210 06 CT    0.0475    3.500     0.066     all-atom C: CH2, sulfides OPLS-AA/L                     
+ 211 06 CT    0.1175    3.500     0.066     all-atom C: CH, sulfides OPLS-AA/L                      
+ 212 06 CT    0.1675    3.500     0.066     all-atom C: C, sulfides OPLS-AA/L                       
+ 213 06 CT    0.0375    3.500     0.066     all-atom C: CH3, disulfides                             
+ 214 06 CT    0.0975    3.500     0.066     all-atom C: CH2, disulfides                             
+ 215 06 CT    0.1575    3.500     0.066     all-atom C: CH, disulfides                              
+ 216 06 CT    0.2175    3.500     0.066     all-atom C: C, disulfides                               
+ 217 06 CT    0.000     3.500     0.066     all-atom C: CH3, methanethiol                           
+ 218 06 CT    0.200     3.500     0.066     C in CH2OH - benzyl alcohols                            
+ 219 06 CT    0.260     3.500     0.066     C in CHROH - benzyl alcohols                            
+ 220 06 CT    0.320     3.500     0.066     C in CR2OH - benzyl alcohols                            
+ 221 06 CA   -0.055     3.550     0.068     C(CH2OH)   - benzyl alcohols, nitriles                  
+ 222 16 S    -0.320     3.600     0.355     S in thioanisoles OPLS-AA/L                             
+ 223 06 CT    0.080     3.500     0.066     C in RCH2NH2 and Gly CA (See 900 for amines)            
+ 224 06 CT    0.140     3.500     0.066     C in R2CHNH2 and Ala CA                                 
+ 225 06 CT    0.200     3.500     0.066     C in R3CNH2 and Aib  CA                                 
+ 226 17 Cl   -0.120     3.400     0.300     chloroalkene Cl (ClH-C=) - see also 398                 
+ 227 06 CM    0.005     3.550     0.076     chloroalkene C (ClH-C=)                                 
+ 228 06 CA    0.1025    3.550     0.068     C(SMe)  thioanisole                                     
+ 229 06 CT    0.140     3.500     0.066     C on N: secondary N-CHR2 amide                          
+ 230 06 CT    0.200     3.500     0.066     C on N: secondary N-CR3  amide                          
+ 231 06 C     0.700     3.750     0.105     C: C=O in benzophenone                                  
+ 232 06 C     0.565     3.750     0.105     C: C=O in benzaldehyde                                  
+ 233 06 C     0.585     3.750     0.105     C: C=O in acetophenone                                  
+ 234 06 C     0.615     3.750     0.105     C: C=O in benzamide                                     
+ 235 06 C     0.500     3.750     0.105     C: C=O in amide.   Acyl R in amides                     
+ 236 08 O    -0.500     2.960     0.210     O: C=O in amide.   is neutral - use                     
+ 237 07 N    -0.760     3.250     0.170     N: primary amide.  alkane parameters.                   
+ 238 07 N    -0.500     3.250     0.170     N: secondary amide  279 for formyl H.                   
+ 239 07 N    -0.140     3.250     0.170     N: tertiary amide   NEW TERT AMIDE PARAMETERS:          
+ 240 01 H     0.380     0.0       0.0       H on N: primary amide     see 1035-1045                 
+ 241 01 H     0.300     0.0       0.0       H on N: secondary amide                                 
+ 242 06 CT    0.020     3.500     0.066     C on N: secondary N-Me amide                            
+ 243 06 CT   -0.110     3.500     0.066     C on N: tertiary  N-Me amide                            
+ 244 06 CT    0.080     3.500     0.066     C on N: secondary N-CH2R amide                          
+ 245 06 CT   -0.050     3.500     0.066     C on N: tertiary  N-CH2R amide (Pro Cdelta)             
+ 246 06 CT    0.010     3.500     0.066     C on N: tertiary  N-CHR2 amide (Pro Calpha)             
+ 247 06 C     0.142     3.750     0.105     C in O=C(NH2)2  Urea                                    
+ 248 08 O    -0.390     2.960     0.210     O in O=C(NH2)2  Urea Isr. J. Chem                       
+ 249 07 N    -0.542     3.250     0.170     N in O=C(NH2)2  Urea 33, 323 (93)                       
+ 250 01 H     0.333     0.0       0.0       H in O=C(NH2)2  Urea                                    
+ 251 07 N    -0.490     3.250     0.170     N   in imide                                            
+ 252 06 C     0.420     3.750     0.105     C(=O) in imide                                          
+ 253 08 O    -0.420     2.960     0.210     O   in imide                                            
+ 254 01 H     0.370     0.000     0.000     H(N) in imide                                           
+ 255 01 HC    0.060     2.500     0.020     H(C) in formimide                                       
+ 256 06 CT   -0.120     3.500     0.066     C in CH3  imide                                         
+ 257 06 CT   -0.060     3.500     0.066     C in RCH2 imide                                         
+ 258 06 CT    0.000     3.500     0.066     C in R2CH imide                                         
+ 259 06 CT    0.060     3.500     0.066     C in R3C  imide                                         
+ 260 06 CA    0.035     3.550     0.068     C(CN)  benzonitrile cyano                               
+ 261 06 CZ    0.395     3.650     0.150     C(N)   benzonitrile                                     
+ 262 07 NZ   -0.430     3.200     0.170     N      benzonitrile                                     
+ 263 06 CA    0.180     3.550     0.068     C(Cl)  chlorobenzene                                    
+ 264 17 Cl   -0.180     3.400     0.300     Cl     chlorobenzene                                    
+ 265 07 N    -0.385     3.250     0.170     N: N-phenylacetamide                                    
+ 266 06 CA    0.085     3.550     0.068     ipso C in N-phenylacetamide                             
+ 267 06 C     0.520     3.750     0.105     Co in CCOOH carboxylic acid                             
+ 268 08 OH   -0.530     3.000     0.170     Oh in CCOOH R in RCOOH is                               
+ 269 08 O    -0.440     2.960     0.210     Oc in CCOOH neutral; use 135-140                        
+ 270 01 HO    0.450     0.0       0.0       H  in CCOOH                                             
+ 271 06 C     0.700     3.750     0.105     C in COO- carboxylate                                   
+ 272 08 O2   -0.800     2.960     0.210     O: O in COO- carboxylate                                
+ 273 06 CT   -0.280     3.500     0.066     C: CH3, carboxylate ion                                 
+ 274 06 CT   -0.220     3.500     0.066     C: CH2, carboxylate ion                                 
+ 275 06 CT   -0.160     3.500     0.066     C: CH,  carboxylate ion                                 
+ 276 06 CT   -0.100     3.500     0.066     C: C,   carboxylate ion                                 
+ 277 06 C     0.450     3.750     0.105     AA C: aldehyde & acyl halide - for C-alpha use          
+ 278 08 O    -0.450     2.960     0.210     AA O: aldehyde & acyl halide - 135-139                  
+ 279 01 HC    0.000     2.420     0.030     AA H-alpha in aldehyde & formamide                      
+ 280 06 C     0.470     3.750     0.105     AA C: ketone - for C-alpha use                          
+ 281 08 O    -0.470     2.960     0.210     AA O: ketone - 135-139                                  
+ 282 01 HC    0.060     2.420     0.015     AA H on C-alpha in ketone & aldehyde & acyl halide      
+ 283 06 CT    0.040     3.500     0.066     AA C-alpha on C-terminal ALA                            
+ 284 06 CT   -0.020     3.500     0.066     AA C-alpha on C-terminal GLY                            
+ 285 06 CT   -0.090     3.500     0.066     AA C-alpha on C-terminal PRO                            
+ 286 07 N3   -0.40      3.480     0.290     N (NH4+) JPC,90,2174 (1986)  N3 sigma and eps changed 5/
+ 287 07 N3   -0.30      3.480     0.290     N (RNH3+)       "                                       
+ 288 07 N3    0.00      3.480     0.290     N (R4N+)        "  Ammonium Ions                        
+ 289 01 H3    0.35      0.0       0.0       H (NH4+)        "  see also 940-945,                    
+ 290 01 H3    0.33      0.0       0.0       H (RNH3+)       "  1120-1130, 309-310                   
+ 291 06 CT    0.130     3.500     0.066     C in  CH3NH3+                                           
+ 292 06 CT    0.190     3.500     0.066     C in  RCH2NH3+ & CA in N-term Gly                       
+ 293 06 CT    0.250     3.500     0.066     C in  R2CHNH3+ & CA in N-term Ala, etc.                 
+ 294 06 CT    0.310     3.500     0.066     C in  R3CNH3+                                           
+ 295 06 CT    0.230     3.500     0.066     AA:C-alpha in N-term PRO                                
+ 296 06 CT    0.170     3.500     0.066     AA:C-delta in N-term PRO                                
+ 297 06 CT    0.110     3.500     0.066     CT in  CH3NH2+R                                         
+ 298 06 CT    0.090     3.500     0.066     AA C-alpha in Gly zwitterion                            
+ 299 06 CT    0.150     3.500     0.066     AA C-alpha in Ala zwitterion                            
+ 300 07 N2   -0.800     3.250     0.170     N: guanidinium NH2                                      
+ 301 01 H3    0.460     0.0       0.0       H: guanidinium NH2                                      
+ 302 06 CA    0.640     3.550     0.050     C: guanidinium C+                                       
+ 303 07 N2   -0.700     3.250     0.170     N: guanidinium NHR                                      
+ 304 01 H3    0.440     0.0       0.0       H: guanidinium NHR                                      
+ 305 06 CT    0.200     3.500     0.066     C: CH3, methylguanidinium                               
+ 306 06 CT   -0.110     3.500     0.066     C: CH3, ethylguanidinium                                
+ 307 06 CT    0.190     3.500     0.066     C: CH2(D), ARG, ethylguanidinium                        
+ 308 06 CT   -0.050     3.500     0.066     C: CH2(G), ARG                                          
+ 309 07 N3   -0.20      3.480     0.290     N (R2NH2+)                                              
+ 310 01 H3    0.31      0.0       0.0       H (R2NH2+)                                              
+ 311 07 NC   -0.46      3.25      0.17      DAP N1   Diamino-                                       
+ 312 06 CA    0.36      3.50      0.08      DAP C2   pyridine                                       
+ 313 07 N2   -0.85      3.25      0.17      DAP N-amine                                             
+ 314 01 H     0.37      0.0       0.0       DAP H-amine                                             
+ 315 06 CA   -0.15      3.50      0.08      DAP C3                                                  
+ 316 01 HA    0.10      2.50      0.05      DAP H3                                                  
+ 317 06 CA   -0.04      3.50      0.08      DAP C4                                                  
+ 318 01 HA    0.10      2.50      0.05      DAP H4                                                  
+ 319 07 NA   -0.60      3.25      0.17      Uracil N1 -use 938 for nucleoside                       
+ 320 06 C     0.50      3.75      0.105     Uracil C2                                               
+ 321 07 NA   -0.51      3.25      0.17      Uracil N3                                               
+ 322 06 C     0.45      3.75      0.105     Uracil C4                                               
+ 323 06 CM   -0.07      3.50      0.08      Uracil C5                                               
+ 324 06 CM    0.08      3.50      0.08      Uracil C6                                               
+ 325 01 H     0.41      0.0       0.0       Uracil H-N1                                             
+ 326 08 O    -0.40      2.96      0.210     Uracil O-C2                                             
+ 327 01 H     0.36      0.0       0.0       Uracil H-N3                                             
+ 328 08 O    -0.42      2.96      0.210     Uracil O-C4                                             
+ 329 01 HC    0.10      2.50      0.05      Uracil H-C5                                             
+ 330 01 HC    0.10      2.50      0.05      Uracil H-C6  Thymine                                    
+ 331 06 CT   -0.14      3.50      0.08      Thymine C-C5                                            
+ 332 01 HC    0.08      2.50      0.05      Thymine H-CC5                                           
+ 333 07 NA   -0.56      3.25      0.17      Cytosine N1 -use 937 for nucleoside                     
+ 334 06 C     0.55      3.75      0.105     Cytosine C2                                             
+ 335 07 NC   -0.54      3.25      0.17      Cytosine N3                                             
+ 336 06 CA    0.46      3.50      0.08      Cytosine C4     Nucleotide base                         
+ 337 06 CM   -0.06      3.50      0.08      Cytosine C5     parameters:                             
+ 338 06 CM    0.10      3.50      0.08      Cytosine C6     JACS,113,2810(1991)                     
+ 339 01 H     0.38      0.0       0.0       Cytosine H-N1                                           
+ 340 08 O    -0.48      2.96      0.21      Cytosine O-C2                                           
+ 341 07 N2   -0.79      3.25      0.17      Cytosine N-C4                                           
+ 342 01 H     0.385     0.0       0.0       Cytosine H-NC4/N3                                       
+ 343 01 H     0.355     0.0       0.0       Cytosine H-NC4/C5                                       
+ 344 01 HC    0.10      2.50      0.05      Cytosine H-C5                                           
+ 345 01 HA    0.10      2.50      0.05      Cytosine H-C6                                           
+ 346 07 NC   -0.53      3.25      0.17      Adenine N1                                              
+ 347 06 CQ    0.22      3.50      0.08      Adenine C2                                              
+ 348 07 NC   -0.55      3.25      0.17      Adenine N3                                              
+ 349 06 CB    0.38      3.50      0.08      Adenine C4                                              
+ 350 06 CB    0.15      3.50      0.08      Adenine C5                                              
+ 351 06 CA    0.44      3.50      0.08      Adenine C6                                              
+ 352 07 NB   -0.49      3.25      0.17      Adenine N7 Guanine                                      
+ 353 06 CR    0.20      3.50      0.08      Adenine C8 Guanine                                      
+ 354 07 NA   -0.50      3.25      0.17      Adenine N9 Guanine -use 936 for                         
+ 355 01 HA    0.20      2.50      0.05      Adenine H-C2        nucleoside                          
+ 356 07 N2   -0.81      3.25      0.17      Adenine N-C6                                            
+ 357 01 H     0.385     0.0       0.0       Adenine H-NC6/N1                                        
+ 358 01 H     0.355     0.0       0.0       Adenine H-NC6/C5                                        
+ 359 01 HA    0.20      2.50      0.05      Adenine H-C8 Guanine                                    
+ 360 01 H     0.35      0.0       0.0       Adenine H-N9 Guanine                                    
+ 361 07 NA   -0.56      3.25      0.17      Guanine N1                                              
+ 362 06 CA    0.46      3.50      0.08      Guanine C2                                              
+ 363 07 NC   -0.51      3.25      0.17      Guanine N3                                              
+ 364 06 CB    0.34      3.50      0.08      Guanine C4                                              
+ 365 06 CB    0.12      3.50      0.08      Guanine C5                                              
+ 366 06 C     0.52      3.75      0.105     Guanine C6                                              
+ 367 01 H     0.38      0.0       0.0       Guanine H-N1                                            
+ 368 07 N2   -0.80      3.25      0.17      Guanine N-C2                                            
+ 369 01 H     0.40      0.0       0.0       Guanine H-NC2                                           
+ 370 08 O    -0.51      2.96      0.21      Guanine O-C6                                            
+ 371 06 CT   -0.01      3.50      0.08      9-Me A or G C-N9                                        
+ 372 01 HC    0.12      2.50      0.05      9-Me A or G H-CN9                                       
+ 373 06 CT   -0.01      3.50      0.08      1-Me U or T C-N1                                        
+ 374 01 HC    0.14      2.50      0.05      1-Me U or T H-CN1                                       
+ 375 06 CT   -0.01      3.50      0.08      1-Me Cytosine C-N1                                      
+ 376 01 HC    0.13      2.50      0.05      1-Me Cytosine H-CN1                                     
+ 377 07 NA   -0.64      3.25      0.17      CytH+ N1 Use AT = N* for nucleoside.                    
+ 378 06 C     0.65      3.75      0.105     CytH+ C2                                                
+ 379 07 NA   -0.74      3.25      0.17      CytH+ N3    Protonated cytosine.                        
+ 380 06 CA    0.66      3.50      0.08      CytH+ C4                                                
+ 381 06 CM   -0.06      3.50      0.08      CytH+ C5                                                
+ 382 06 CM    0.10      3.50      0.08      CytH+ C6                                                
+ 383 01 H     0.49      0.0       0.0       CytH+ H-N1                                              
+ 384 08 O    -0.30      2.96      0.21      CytH+ O-C2                                              
+ 385 01 H     0.48      0.0       0.0       CytH+ H-N3                                              
+ 386 07 N2   -0.81      3.25      0.17      CytH+ N-C4                                              
+ 387 01 H     0.46      0.0       0.0       CytH+ H-NC4/N3                                          
+ 388 01 H     0.43      0.0       0.0       CytH+ H-NC4/C5                                          
+ 389 01 HA    0.14      2.50      0.05      CytH+ H-C5                                              
+ 390 01 HA    0.14      2.50      0.05      CytH+ H-C6                                              
+ 391 06 CT    0.01      3.50      0.08      1-Me CytH+ C-N1                                         
+ 392 01 HC    0.16      2.50      0.05      1-Me CytH+ H-CN1                                        
+ 393 15 P     0.780     3.740     0.200     P    dimethylphosphate anion                            
+ 394 08 O2   -0.660     2.960     0.210     O(=)          "  OPLS UA                                
+ 395 08 OS   -0.430     3.000     0.170     O             "  see 440                                
+ 396 06 CT    0.020     3.550     0.066     C in CH3      "  for AA                                 
+ 397 06 CM    0.18      3.50      0.08      F3C-C5 thymine; trifluorothymine                        
+ 398 17 Cl   -0.060     3.400     0.300     chloroalkene Cl (Cl2-C=) - tentative                    
+ 399 06 CM    0.120     3.550     0.076     chloroalkene C (Cl2-C=)  - tentaive                     
+#                                                                                                   
+ 400 09 F    -1.0       3.05      0.71      F-                                                      
+ 401 17 Cl   -1.0       4.02      0.71      Cl-                                                     
+ 402 35 Br   -1.0       4.28      0.71      Br-                                                     
+ 403 53 I    -1.0       4.81      0.71      I-    400-410 new OPLS:                                 
+ 404                                                                                                
+ 405 07 N3    1.0       5.34      0.0005    NH4+  K Jensen                                          
+ 406 03 Li    1.0       2.87      0.0005    Li+   JCTC 2, 1499 (2006)                               
+ 407 11 Na    1.0       4.07      0.0005    Na+                                                     
+ 408 19 K     1.0       5.17      0.0005    K+                                                      
+ 409 37 Rb    1.0       5.60      0.0005    Rb+                                                     
+ 410 55 Cs    1.0       6.20      0.0005    Cs+                                                     
+#                                                Old ion parameters:                                
+# 400 09 F    -1.0       2.73295   0.72000   F-  JACS 106, 903 (1984)                               
+# 401 17 Cl   -1.0       4.41724   0.11779   Cl- JACS 106, 903 (1984)                               
+# 402 35 Br   -1.0       4.62376   0.09000   Br- JACS 107, 7793(1985)                               
+# 403 53 I    -1.0       5.40000   0.07000   I-  JACS 120, 5104(1998)                               
+# 404 03 Li    1.0       1.25992   6.25000   Li+ JACS 106, 903 (1984)                               
+# 405 11 Na    1.0       1.89744   1.60714   Na+ JACS 106, 903 (1984)                               
+# 406 03 Li    1.00     2.126452  0.018279   Li+                                                    
+# 407 11 Na    1.00     3.330445  0.002772   Na+    Aqvist's cation                                 
+# 408 19 K     1.00     4.934628  0.000328   K+     parameters:                                     
+# 409 37 Rb    1.00     5.621773  0.000171   Rb+    JPC,94, 8021 (90)                               
+# 410 55 Cs    1.00     6.715999  0.000081   Cs+                                                    
+ 411 12 Mg    2.00     1.644471  0.875044   Mg++                                                    
+ 412 20 Ca    2.00     2.412031  0.449657   Ca++                                                    
+ 413 38 Sr    2.00     3.102688  0.118226   Sr++                                                    
+ 414 56 Ba    2.00     3.816610  0.047096   Ba++                                                    
+#                                                                                                   
+ 415 06 C3   -0.40     4.20      0.30       C  in  CH3S-  thiolate                                  
+ 416 01 HC    0.10     2.50      0.05       H  in  CH3S-                                            
+ 417 16 SH   -0.90     4.25      0.50       S  in  CH3S-                                            
+ 418 06 C3   -0.20     4.20      0.30       C  in  CH3O-  alkoxide                                  
+ 419 01 HC    0.06     2.50      0.05       H  in  CH3O-                                            
+ 420 08 OH   -0.98     3.15      0.25       O  in  CH3O-                                            
+ 421 06 CT   -1.07     4.20      0.30       C1 in  CH2CN-  RCN-                                     
+ 422 01 HC    0.19     2.50      0.05       H  in  CH2CN-                                           
+ 423 06 CZ    0.51     3.65      0.15       C2 in  CH2CN-   JACS 111,                               
+ 424 07 NZ   -0.82     3.40      0.25       N  in  CH2CN-   4190 (89)                               
+ 425 06 C3   -0.30     4.20      0.30       C  in  CH3NH-                                           
+ 426 01 HC    0.07     2.50      0.05       HC in  CH3NH-  RNH-                                     
+ 427 07 NC   -1.31     3.40      0.25       N  in  CH3NH-                                           
+ 428 01 H     0.40     2.50      0.05       HN in  CH3NH-                                           
+ 429 06 C3   -0.40     4.20      0.30       C2 in  CH3CH2- RCH2-                                    
+ 430 01 HC    0.08     2.50      0.05       H  in  CH3CH2-                                          
+ 431 06 CT    0.00     4.20      0.30       C1 in  CH3CH2-                                          
+ 432 01 HC    0.07     2.50      0.05       H1 in  CH3CH2-                                          
+ 433 02 LP   -0.98     0.0       0.0        LP in  CH3CH2-                                          
+ 434 08 OH   -1.300    3.200     0.250      O in OH-  Hyroxide O-H = 0.953 A                        
+ 435 01 HO    0.300    0.0       0.0        H in OH-  JACS 108, 2517 (86)                           
+ 436 92 U     2.500    2.81524   0.400      U in UO2+ J Mol Struct 366, 55 (96)                     
+ 437 08 OU   -0.250    3.11815   0.200      O in UO2+ r(U-O) = 1.80 A                               
+ 438 06 CT    0.27     3.50      0.066      C  in  dimetyl phosphate                                
+ 439 08 OS   -0.865    2.90      0.140      O-(POn)2 in GTP (JT-R 4/4/05)                           
+ 440 15 P     1.62     3.74      0.200      P  in  Me2PO4-                                          
+ 441 08 O2   -0.92     3.15      0.200      O= in   "                                               
+ 442 08 OS   -0.60     2.90      0.140      O  in   "     dimethyl                                  
+ 443 06 CT    0.30     3.50      0.066      C  in   "     phosphate                                 
+ 444 01 HC   -0.03     2.50      0.030      H  in   "     6-31+G* CHELPG                            
+ 445 15 P     1.92     3.74      0.200      P  in  MeOPO3--                                         
+ 446 08 O2   -1.12     3.15      0.200      O= in   "                                               
+ 447 08 OS   -0.70     2.90      0.140      O  in   "     methyl phosphate                          
+ 448 06 CT    0.44     3.50      0.066      C  in   "     6-31+G* CHELPG                            
+ 449 01 HC   -0.10     2.50      0.030      H  in   "                                               
+ 450 15 P     1.62     3.74      0.200      P  in  MePO3Me-                                         
+ 451 08 O2   -0.97     3.15      0.200      O= in   "                                               
+ 452 08 OS   -0.63     2.90      0.140      O  in   "     methyl                                    
+ 453 06 CT    0.28     3.50      0.066      C(O)    "     methylphosphonate                         
+ 454 01 HC   -0.02     2.50      0.030      H(CO)   "     6-31+G* CHELPG                            
+ 455 06 CT   -0.51     3.50      0.066      C(P)    "                                               
+ 456 01 HC    0.08     2.50      0.030      H(CP)   "                                               
+ 457 06 CA   -0.14     3.55      0.068      Cipso  benzyl methylphosphonate                         
+ 458 06 CT    0.32     3.50      0.066      C(O)    "           "                                   
+ 459 01 HC    0.02     2.50      0.030      H(CO)   "           "                                   
+ 460 06 CA   -0.04     3.55      0.068      Cipso  methyl benzylphosphonate                         
+ 461 06 CT   -0.47     3.50      0.066      C(P)    "           "                                   
+ 462 01 HC    0.12     2.50      0.030      H(CP)   "           "                                   
+ 463 06 CA    0.14     3.55      0.068      Cipso C6H5OPO3(2-)  use with 445-7                      
+ 464 06 CT    0.24     3.500     0.066      C6(R2) of barbiturate                                   
+ 465 06 C     0.490    3.750     0.105      AA C:   esters   - for R on C=O, use                    
+ 466 08 O    -0.410    2.960     0.140      AA =O:  esters   ketone params (see 280-282)            
+ 467 08 OS   -0.330    3.000     0.120      AA -OR: ester -                                         
+ 468 06 CT    0.160    3.500     0.066      methoxy C in esters - see also 490-492  OPLS/2020       
+ 469 01 HC    0.030    2.480     0.026      alkoxy H's in esters                                    
+ 470 06 C     0.635    3.750     0.105      Co in benzoic acid                                      
+ 471 06 C     0.605    3.750     0.105      Co in methyl benzoate, aryl ester                       
+ 472 06 CA    0.135    3.550     0.068      Cipso phenyl ester                                      
+ 473 08 OS   -0.215    3.000     0.170      AA -OR phenyl ester                                     
+ 474 16 SY    1.48     3.55      0.25       S in sulfonamide                                        
+ 475 08 OY   -0.68     2.96      0.17       O in sulfonamide                                        
+ 476 06 CT   -0.54     3.50      0.066      CH3 attached to S of sulfonamide                        
+ 477 01 HC    0.18     2.50      0.030      H of Me attached to S of sulfonamide                    
+ 478 07 N    -1.00     3.250     0.170      N: primary amide of sulfonamide                         
+ 479 01 H     0.44     0.0       0.0        H on N: primary sulfonamide                             
+ 480 07 N    -0.80     3.250     0.170      N secondary amide of sulfonamide                        
+ 481 01 H     0.41     0.0       0.0        H on N: secondary sulfonamide                           
+ 482 06 CT    0.18     3.50      0.066      alpha CH3-N of sulfonamide                              
+ 483 01 HC    0.03     2.50      0.030      H of alpha CH3-N of sulfonamide                         
+ 484 06 CT    0.39     3.50      0.066      alpha CH2-N of sulfonamide                              
+ 485 01 HC   -0.06     2.50      0.030      H of alpha CH2-N of sulfonamide                         
+ 486 06 CT   -0.18     3.50      0.066      beta CH3 of N-ethyl sulfonamide                         
+ 487 01 HC    0.06     2.50      0.030      H of beta CH3 of N-ethyl sulfonamide                    
+ 488 06 CA    0.00     3.55      0.068      benzene C attached to S of sulfonamide                  
+ 489 06 CA    0.03     3.55      0.068      benzene C attached to S of alkyl aryl sulfoxide         
+ 490 06 CT    0.19     3.500     0.066      C(H2OS) ethyl ester                                     
+ 491 06 CT    0.22     3.500     0.066      C(HOS) i-pr ester                                       
+ 492 06 CT    0.25     3.500     0.066      C(OS) t-bu ester                                        
+ 493 16 SY    1.374    3.55      0.25       S in sulfone                                            
+ 494 08 OY   -0.687    2.96      0.17       O in sulfone                                            
+ 495 16 SZ    0.245    3.56      0.395      alkyl aryl sulfoxide - all atom                         
+ 496 16 SZ    0.130    3.56      0.395      sulfoxide - all atom                                    
+ 497 08 OY   -0.420    2.93      0.280      sulfoxide - all atom                                    
+ 498 06 CT   -0.035    3.500     0.066      CH3 all-atom C: sulfoxide                               
+ 499 06 CT    0.025    3.500     0.066      CH2 all-atom C: sulfoxide                               
+ 500 06 CS    0.075    3.550     0.070      CG in TRP                                               
+ 501 06 CB   -0.055    3.550     0.070      CD C in TRP                                             
+ 502 06 CN    0.130    3.550     0.070      CE C in TRP                                             
+ 503 07 NA   -0.570    3.250     0.170      NE in TRP                                               
+ 504 01 H     0.420    0.000     0.000      H on NE in TRP                                          
+ 505 06 CT   -0.005    3.500     0.066      CB in HIS                                               
+ 506 06 CR    0.295    3.550     0.070      CE1 in HID, HIE                                         
+ 507 06 CV   -0.015    3.550     0.070      CD2 in HID, CG in HIE                                   
+ 508 06 CW    0.015    3.550     0.070      CG in HID, CD2 in HIE                                   
+ 509 06 CR    0.385    3.550     0.070      CE1 in HIP                                              
+ 510 06 CX    0.215    3.550     0.070      CG, CD2 in HIP                                          
+ 511 07 NB   -0.490    3.250     0.170      NE in HID, ND in HIE                                    
+ 512 07 NA   -0.540    3.250     0.170      N in HIP                                                
+ 513 01 H     0.460    0.000     0.000      H on N in HIP                                           
+ 514 06 CW   -0.115    3.550     0.070      CD1 in TRP                                              
+ 515 06 CT    0.055    3.500     0.066      all-atom C: CH, isopropyl benzene                       
+ 516 06 CT    0.115    3.500     0.066      all-atom C: C,  t-butyl benzene                         
+ 517 06 CM   -0.030    3.550     0.076      vinyl ether HCOR                                        
+ 518 06 CM    0.085    3.550     0.076      vinyl ether RCOR                                        
+ 519 06 C!    0.000    3.550     0.068      biphenyl C1                                             
+ 520 07 NC   -0.678    3.250     0.170      N   in pyridine 6-31G*                                  
+ 521 06 CA    0.473    3.550     0.070      C1  in pyridine CHELPG                                  
+ 522 06 CA   -0.447    3.550     0.070      C2  in pyridine charges                                 
+ 523 06 CA    0.227    3.550     0.070      C3  in pyridine for                                     
+ 524 01 HA    0.012    2.420     0.030      H1  in pyridine 520-656                                 
+ 525 01 HA    0.155    2.420     0.030      H2  in pyridine                                         
+ 526 01 HA    0.065    2.420     0.030      H3  in pyridine                                         
+ 527 07 NC   -0.468    3.250     0.170      N   in pyrazine                                         
+ 528 06 CA    0.192    3.550     0.070      C   in pyrazine                                         
+ 529 01 HA    0.042    2.420     0.030      H   in pyrazine                                         
+ 530 07 NC   -0.839    3.250     0.170      N   in pyrimidine                                       
+ 531 06 CQ    0.874    3.550     0.070      C2  in pyrimidine                                       
+ 532 06 CA    0.653    3.550     0.070      C4  in pyrimidine                                       
+ 533 06 CA   -0.689    3.550     0.070      C5  in pyrimidine                                       
+ 534 01 HA   -0.032    2.420     0.030      H2  in pyrimidine                                       
+ 535 01 HA    0.011    2.420     0.030      H4  in pyrimidine                                       
+ 536 01 HA    0.197    2.420     0.030      H5  in pyrimidine                                       
+ 537 07 NC   -0.331    3.250     0.170      N   in pyridazine                                       
+ 538 06 CA    0.378    3.550     0.070      C3  in pyridazine                                       
+ 539 06 CA   -0.160    3.550     0.070      C4  in pyridazine                                       
+ 540 01 HA   -0.009    2.420     0.030      H3  in pyridazine                                       
+ 541 01 HA    0.122    2.420     0.030      H4  in pyridazine                                       
+ 542 07 NA   -0.239    3.250     0.170      N   in pyrrole                                          
+ 543 06 CW   -0.163    3.550     0.070      C2  in pyrrole                                          
+ 544 06 CS   -0.149    3.550     0.070      C3  in pyrrole                                          
+ 545 01 H     0.317    0.000     0.000      H1  in pyrrole                                          
+ 546 01 HA    0.155    2.420     0.030      H2  in pyrrole                                          
+ 547 01 HA    0.118    2.420     0.030      H3  in pyrrole                                          
+ 548 07 NA   -0.059    3.250     0.170      N1  in pyrazole                                         
+ 549 07 NB   -0.491    3.250     0.170      N2  in pyrazole                                         
+ 550 06 CU    0.246    3.550     0.070      C3  in pyrazole                                         
+ 551 06 CS   -0.320    3.550     0.070      C4  in pyrazole                                         
+ 552 06 CW   -0.034    3.550     0.070      C5  in pyrazole                                         
+ 553 01 H     0.301    0.000     0.000      H1  in pyrazole                                         
+ 554 01 HA    0.072    2.420     0.030      H3  in pyrazole                                         
+ 555 01 HA    0.150    2.420     0.030      H4  in pyrazole                                         
+ 556 01 HA    0.135    2.420     0.030      H5  in pyrazole                                         
+ 557 07 NA   -0.257    3.250     0.170      N1  in imidazole                                        
+ 558 06 CR    0.275    3.550     0.070      C2  in imidazole                                        
+ 559 07 NB   -0.563    3.250     0.170      N3  in imidazole                                        
+ 560 06 CV    0.185    3.550     0.070      C4  in imidazole                                        
+ 561 06 CW   -0.286    3.550     0.070      C5  in imidazole                                        
+ 562 01 H     0.306    0.000     0.000      H1  in imidazole                                        
+ 563 01 HA    0.078    2.420     0.030      H2  in imidazole                                        
+ 564 01 HA    0.075    2.420     0.030      H4  in imidazole                                        
+ 565 01 HA    0.187    2.420     0.030      H5  in imidazole                                        
+ 566 08 OA   -0.190    2.900     0.140      O   in furan                                            
+ 567 06 CW   -0.019    3.550     0.070      C2  in furan                                            
+ 568 06 CS   -0.154    3.550     0.076      C3  in furan                                            
+ 569 01 HA    0.142    2.420     0.030      H2  in furan                                            
+ 570 01 HA    0.126    2.420     0.030      H3  in furan                                            
+ 571 08 OS   -0.257    2.900     0.140      O   in oxazole                                          
+ 572 06 CR    0.511    3.550     0.070      C2  in oxazole                                          
+ 573 07 NB   -0.590    3.250     0.170      N   in oxazole                                          
+ 574 06 CV    0.169    3.550     0.070      C4  in oxazole                                          
+ 575 06 CW   -0.148    3.550     0.070      C5  in oxazole                                          
+ 576 01 HA    0.043    2.420     0.030      H2  in oxazole                                          
+ 577 01 HA    0.091    2.420     0.030      H4  in oxazole                                          
+ 578 01 HA    0.181    2.420     0.030      H5  in oxazole                                          
+ 579 08 OS   -0.122    2.900     0.140      O   in isoxazole                                        
+ 580 07 NB   -0.413    3.250     0.170      N   in isoxazole                                        
+ 581 06 CU    0.405    3.550     0.070      C3  in isoxazole                                        
+ 582 06 CS   -0.455    3.550     0.070      C4  in isoxazole                                        
+ 583 06 CW    0.250    3.550     0.070      C5  in isoxazole                                        
+ 584 01 HA    0.053    2.420     0.030      H3  in isoxazole                                        
+ 585 01 HA    0.184    2.420     0.030      H4  in isoxazole                                        
+ 586 01 HA    0.098    2.420     0.030      H5  in isoxazole                                        
+ 587 07 NA   -0.500    3.250     0.170      N1  in indole                                           
+ 588 06 CW    0.001    3.550     0.070      C2  in indole                                           
+ 589 06 CS   -0.390    3.550     0.070      C3  in indole                                           
+ 590 06 CA   -0.270    3.550     0.070      C4  in indole                                           
+ 591 06 CA   -0.127    3.550     0.070      C5  in indole                                           
+ 592 06 CA   -0.108    3.550     0.070      C6  in indole                                           
+ 593 06 CA   -0.258    3.550     0.070      C7  in indole                                           
+ 594 06 CW    0.220    3.550     0.070      C8  in indole                                           
+ 595 06 CS    0.225    3.550     0.070      C9  in indole                                           
+ 596 01 H     0.376    0.000     0.000      H1  in indole                                           
+ 597 01 HA    0.147    2.420     0.030      H2  in indole                                           
+ 598 01 HA    0.172    2.420     0.030      H3  in indole                                           
+ 599 01 HA    0.155    2.420     0.030      H4  in indole                                           
+ 600 01 HA    0.107    2.420     0.030      H5  in indole                                           
+ 601 01 HA    0.110    2.420     0.030      H6  in indole                                           
+ 602 01 HA    0.140    2.420     0.030      H7  in indole                                           
+ 603 07 NC   -0.694    3.250     0.170      N1  in quinoline                                        
+ 604 06 CA    0.425    3.550     0.070      C2  in quinoline                                        
+ 605 06 CA   -0.359    3.550     0.070      C3  in quinoline                                        
+ 606 06 CA   -0.008    3.550     0.070      C4  in quinoline                                        
+ 607 06 CA   -0.197    3.550     0.070      C5  in quinoline                                        
+ 608 06 CA   -0.112    3.550     0.070      C6  in quinoline                                        
+ 609 06 CA   -0.070    3.550     0.070      C7  in quinoline                                        
+ 610 06 CA   -0.307    3.550     0.070      C8  in quinoline                                        
+ 611 06 CA    0.563    3.550     0.070      C9  in quinoline                                        
+ 612 06 CA   -0.051    3.550     0.070      C10 in quinoline                                        
+ 613 01 HA    0.028    2.420     0.030      H2  in quinoline                                        
+ 614 01 HA    0.146    2.420     0.030      H3  in quinoline                                        
+ 615 01 HA    0.119    2.420     0.030      H4  in quinoline                                        
+ 616 01 HA    0.133    2.420     0.030      H5  in quinoline                                        
+ 617 01 HA    0.113    2.420     0.030      H6  in quinoline                                        
+ 618 01 HA    0.114    2.420     0.030      H7  in quinoline                                        
+ 619 01 HA    0.157    2.420     0.030      H8  in quinoline                                        
+ 620 07 NC   -0.760    3.250     0.170      N1  in purine (9H)                                      
+ 621 06 CQ    0.679    3.550     0.070      C2  in purine                                           
+ 622 07 NC   -0.788    3.250     0.170      N3  in purine                                           
+ 623 06 CB    0.736    3.550     0.070      C4  in purine                                           
+ 624 06 CB    0.038    3.550     0.070      C5  in purine                                           
+ 625 06 CA    0.343    3.550     0.070      C6  in purine                                           
+ 626 07 NB   -0.642    3.250     0.170      N7  in purine                                           
+ 627 06 CR    0.452    3.550     0.070      C8  in purine                                           
+ 628 07 NA   -0.682    3.250     0.170      N9  in purine                                           
+ 629 01 HA    0.024    2.420     0.030      H2  in purine                                           
+ 630 01 HA    0.101    2.420     0.030      H6  in purine                                           
+ 631 01 HA    0.086    2.420     0.030      H8  in purine                                           
+ 632 01 H     0.413    0.000     0.000      H9  in purine                                           
+ 633 16 SA   -0.030    3.600     0.355      S   in thiazole OPLS-AA/L                               
+ 634 06 CR    0.242    3.550     0.070      C2  in thiazole                                         
+ 635 07 NB   -0.515    3.250     0.170      N   in thiazole                                         
+ 636 06 CV    0.228    3.550     0.070      C4  in thiazole                                         
+ 637 06 CW   -0.299    3.550     0.070      C5  in thiazole                                         
+ 638 01 HA    0.101    2.420     0.030      H2  in thiazole                                         
+ 639 01 HA    0.068    2.420     0.030      H4  in thiazole                                         
+ 640 01 HA    0.205    2.420     0.030      H5  in thiazole                                         
+ 641 07 NC   -0.951    3.250     0.170      N   in 1,3,5-triazine                                   
+ 642 06 CQ    0.965    3.550     0.070      C   in 1,3,5-triazine                                   
+ 643 01 HA   -0.014    2.420     0.030      H   in 1,3,5-triazine                                   
+ 644 06 CA    0.130    3.550     0.070      C5  in serotonin                                        
+ 645 06 CT    0.052    3.500     0.066      C on C3 in serotonin                                    
+ 646 07 NC   -0.599    3.250     0.170      N   in 1,10-phenanthroline                              
+ 647 06 CA    0.392    3.550     0.070      C2  in 1,10-phenanthroline                              
+ 648 06 CA   -0.348    3.550     0.070      C3  in 1,10-phenanthroline                              
+ 649 06 CA    0.020    3.550     0.070      C4  in 1,10-phenanthroline                              
+ 650 06 CA   -0.042    3.550     0.070      C12 in 1,10-phenanthroline                              
+ 651 06 CA    0.347    3.550     0.070      C11 in 1,10-phenanthroline                              
+ 652 06 CA   -0.196    3.550     0.070      C5  in 1,10-phenanthroline                              
+ 653 01 HA    0.032    2.420     0.030      H2  in 1,10-phenanthroline                              
+ 654 01 HA    0.146    2.420     0.030      H3  in 1,10-phenanthroline                              
+ 655 01 HA    0.108    2.420     0.030      H4  in 1,10-phenanthroline                              
+ 656 01 HA    0.140    2.420     0.030      H5  in 1,10-phenanthroline                              
+ 657 07 NA    0.122    3.250     0.170      N1  in 1-methylimidazole                                
+ 658 06 CR    0.166    3.550     0.070      C2  in 1-methylimidazole                                
+ 659 07 NB   -0.580    3.250     0.170      N3  in 1-methylimidazole                                
+ 660 06 CV    0.173    3.550     0.070      C4  in 1-methylimidazole                                
+ 661 06 CW   -0.395    3.550     0.070      C5  in 1-methylimidazole                                
+ 662 06 CT   -0.199    3.500     0.066      C1  in 1-methylimidazole                                
+ 663 01 HA    0.118    2.420     0.030      H2  in 1-methylimidazole                                
+ 664 01 HA    0.093    2.420     0.030      H4  in 1-methylimidazole                                
+ 665 01 HA    0.208    2.420     0.030      H5  in 1-methylimidazole                                
+ 666 01 HC    0.098    2.500     0.030      HC1 in 1-methylimidazole                                
+ 667 06 CT   -0.139    3.500     0.066      C1  in 1-ethylimidazole                                 
+ 668 06 CT   -0.079    3.500     0.066      C1  in 1-isopropylimidazole                             
+ 669 06 CT    0.099    3.500     0.066      C1  in 1-MeO-Me-imidazole                               
+ 670 06 CT   -0.168    3.500     0.066      CH3, 2-methyl pyridine                                  
+ 671 06 CT   -0.108    3.500     0.066      CH2, 2-ethyl pyridine                                   
+ 672 06 CT   -0.189    3.500     0.066      CH3, 3-methyl pyridazine                                
+ 673 06 CT   -0.129    3.500     0.066      CH2, 3-ethyl pyridazine                                 
+ 674 06 CT   -0.169    3.500     0.066      CH3, 4-methyl pyrimidine                                
+ 675 06 CT   -0.109    3.500     0.066      CH2, 4-ethyl pyrimidine                                 
+ 676 06 CT   -0.138    3.500     0.066      CH3, 2-methyl pyrazine                                  
+ 677 06 CT   -0.078    3.500     0.066      CH2, 2-ethyl pyrazine                                   
+ 678 06 CT   -0.025    3.500     0.066      CH3, 2-methyl pyrrole                                   
+ 679 06 CT    0.035    3.500     0.066      CH2, 2-ethyl pyrrole                                    
+ 680 06 CT   -0.038    3.500     0.066      CH3, 2-methyl furan                                     
+ 681 06 CT    0.022    3.500     0.066      CH2, 2-ethyl furan                                      
+ 682 16 SH   -0.334    3.600     0.425      S in 6-mercaptopurine OPLS-AA/L                         
+ 683 01 HS    0.255    0.0       0.0        H(S) in 6-mercaptopurine                                
+ 684 06 CA    0.523    3.550     0.070      C6 in 6-mercaptopurine                                  
+ 685 06 C$    0.500    3.750     0.105      C: C=O beta-lactam                                      
+ 686 07 N$   -0.140    3.250     0.170      N: beta-lactam; O is 236                                
+ 687 06 CY    0.2275   3.500     0.066      CH(N):  penicillin                                      
+ 688 06 CY    0.140    3.500     0.066      CH(CO): penicillin                                      
+ 689 06 CT   -0.008    3.500     0.066      CH3, 3-methyl indole                                    
+ 690 06 C!    0.588    3.550     0.070      2-phenyl pyridine C2                                    
+ 691 06 C!   -0.103    3.550     0.070      2-phenyl pyridine C2'                                   
+ 692 06 C!   -0.332    3.550     0.070      3-phenyl pyridine C3                                    
+ 693 06 C!    0.040    3.550     0.070      3-phenyl pyridine C3'                                   
+ 694 06 C!    0.342    3.550     0.070      4-phenyl pyridine C4                                    
+ 695 06 C!   -0.050    3.550     0.070      4-phenyl pyridine C4'                                   
+ 696 16 S    -0.205    3.600     0.355      S in diphenylthioether OPLS-AA/L                        
+ 697 89 Ac    3.000    3.473     0.054      Ac+3 Actinide params -                                  
+ 698 90 Th    4.000    3.300     0.050      Th+4                                                    
+ 699 95 Am    3.000    3.300     0.050      Am+3 F. van Veggel                                      
+ 700 06 C+    0.619    3.550     0.076      C+  in t-butyl+ B3LYP/6-31G*                            
+ 701 06 CT   -0.395    3.500     0.066      C   in t-butyl+   charges                               
+ 702 01 HC    0.174    2.500     0.030      H   in t-butyl+                                         
+ 703 57 La    3.000    3.750     0.060      La+3                                                    
+ 704 60 Nd    3.000    3.473     0.054      Nd+3 Lanthanide params -                                
+ 705 63 Eu    3.000    3.300     0.050      Eu+3 F. van Veggel, Chem Eur J                          
+ 706 64 Gd    3.000    3.300     0.050      Gd+3              5, 90 (1999).                         
+ 707 70 Yb    3.000    2.950     0.040      Yb+3 see also JPC-A 104, 7659 (2000)                    
+ 708 06 CM   -0.344    3.550     0.076      C  in Cl..CH3..Cl- TS                                   
+ 709 17 Cl   -0.628    3.400     0.300      Cl charges: JACS 117,2024 (95)                          
+ 710 01 HC    0.200    2.420     0.030      H  in Cl..CH3..Cl- TS                                   
+ 711 06 CY   -0.12     3.430     0.088      CH2    C: cyclopropane OPLS-2020                        
+ 712 06 CY   -0.06     3.430     0.088      CHR    C: cyclopropane OPLS-2020                        
+ 713 06 CY    0.00     3.430     0.088      CR2    C: cyclopropane OPLS-2020                        
+ 714 06 CY   -0.12     3.470     0.077      CH2    C: cyclobutane  OPLS-2020                        
+ 715 06 CY   -0.06     3.470     0.077      CHR    C: cyclobutane  OPLS-2020                        
+ 716 06 CY    0.00     3.470     0.077      CR2    C: cyclobutane  OPLS-2020                        
+ 718 06 CA    0.280    3.550     0.068      C(F)  fluorobenzene                                     
+ 719 09 F    -0.280    2.850     0.061      F     fluorobenzene                                     
+ 720 06 CA    0.130    3.550     0.068      C(F)  hexafluorobenzene                                 
+ 721 09 F    -0.130    2.850     0.061      F     hexafluorobenzene                                 
+ 722 35 Br   -0.220    3.470     0.470      Br    alkyl bromide (UA)                                
+ 723 06 C2    0.220    3.905     0.118      CH2   alkyl bromide (UA)                                
+ 724 06 CA    0.150    3.550     0.068      C(CF3) trifluoromethylbenzene                           
+ 725 06 CT    0.450    3.250     0.062      CF3           "                                         
+ 726 09 F    -0.200    2.940     0.061      F             "                                         
+ 727 06 CA    0.200    3.550     0.068      C(F)  difluorobenzenes                                  
+ 728 09 F    -0.200    2.850     0.061      F     difluorobenzenes                                  
+ 729 06 CA    0.150    3.550     0.068      C(Br) bromobenzene  JCTC 2012, 8, 3895                  
+ 730 35 Br   -0.150    3.470     0.450      Br    bromobenzene                                      
+ 731 06 CA    0.100    3.550     0.068      C(I)  iodobenzene   sigma CA changed to 0.068           
+ 732 53 I    -0.100    3.800     0.580      I     iodobenzene   in OPLS/2020                        
+ 733 06 CY    0.055    3.500     0.066      all-atom C: CH, cyclopropyl/butyl benzene               
+ 734 16 SH   -0.220    3.600     0.425      all-atom S: thiophenol (HS is #204) OPLS-AA/L           
+ 735 06 CA    0.065    3.550     0.068      C(S)  thiophenol                                        
+ 736 06 CA    0.013    3.550     0.068      CG of Benzamidine                                       
+ 737 06 CA   -0.106    3.550     0.068      CD of Benzamidine                                       
+ 738 06 CA   -0.090    3.550     0.068      CE of Benzamidine                                       
+ 739 06 CA   -0.119    3.550     0.068      CZ of Benzamidine                                       
+ 740 01 HA    0.141    2.420     0.030      HD of Benzamidine                                       
+ 741 01 HA    0.129    2.420     0.030      HE of Benzamidine                                       
+ 742 06 CA    0.827    3.550     0.050      C+ of Benzamidine                                       
+ 743 07 N2   -0.885    3.250     0.170      N-H2 of Benzamidine                                     
+ 744 01 H     0.426    0.000     0.000      H1-N of Benzamidine                                     
+ 745 01 H     0.465    0.000     0.000      H2-N of Benzamidine                                     
+ 746 01 HA    0.119    2.420     0.030      H-CG of Benzamidine                                     
+ 747 06 CT   -0.02     3.500     0.066      CH3 in neutral MeGDN                                    
+ 748 06 CT    0.04     3.500     0.066      CD of neutral ARG                                       
+ 749 07 NY   -0.620    3.25      0.17       NE  "                                                   
+ 750 07 NC   -0.785    3.25      0.17       N1  "    "     " (HN=CZ)                                
+ 751 07 NY   -0.785    3.25      0.17       N2  "    "     " (H2N-CZ)                               
+ 752 06 CA    0.550    3.550     0.050      CZ  "    "     "                                        
+ 753 07 NZ   -0.560    3.200     0.170      N IN RCN  all-atom nitriles                             
+ 754 06 CZ    0.460    3.300     0.066      C IN RCN     "                                          
+ 755 06 CT   -0.080    3.300     0.066      C of CH3 in  CH3CN                                      
+ 756 06 CT   -0.020    3.300     0.066      C of CH2 in RCH2CN                                      
+ 757 06 CT    0.040    3.300     0.066      C of CH  in R2CHCN                                      
+ 758 06 CT    0.100    3.300     0.066      C of C   in R3CCN                                       
+ 759 01 HC    0.06     2.500     0.015      HC-CT-CN alpha-H in nitriles                            
+ 760 07 NO    0.54     3.25      0.12       N in nitro R-NO2                                        
+ 761 08 ON   -0.37     2.96      0.17       O in nitro R-NO2                                        
+ 762 06 CT    0.02     3.500     0.066      CT-NO2 nitromethane                                     
+ 763 01 HC    0.06     2.500     0.015      HC-CT-NO2 alpha-H in nitroalkanes                       
+ 764 06 CT    0.08     3.500     0.066      CT-NO2 nitroethane                                      
+ 765 06 CT    0.14     3.500     0.066      CT-NO2 2-nitropropane                                   
+ 766 06 CT    0.20     3.500     0.066      CT-NO2 2-methyl-2-nitropropane                          
+ 767 07 NO    0.65     3.25      0.12       N in nitro Ar-NO2                                       
+ 768 06 CA    0.09     3.550     0.068      C(NO2) nitrobenzene                                     
+ 769 06 CT    0.035    3.300     0.066      C of CH2 in PhCH2CN                                     
+ 770 07 NC   -0.900    3.250     0.170      N   in neutral benzamidine                              
+ 771 08 O    -0.500    2.960     0.210      propylene carbonate O                                   
+ 772 06 C     0.860    3.750     0.105      " C=O    Lucienne's                                     
+ 773 08 OS   -0.450    3.000     0.170      " OS     parameters                                     
+ 774 06 CT    0.210    3.500     0.066      " C in CH2                                              
+ 775 06 CT    0.160    3.500     0.066      " C in CH                                               
+ 776 06 CT   -0.100    3.500     0.066      " C in CH3  see also 789                                
+ 777 01 HC    0.030    2.420     0.015      " H in CH2                                              
+ 778 01 HC    0.030    2.420     0.015      " H in CH                                               
+ 779 01 HC    0.060    2.420     0.015      " H in CH3                                              
+ 780 08 OS   -0.780    2.90      0.140      O-(POn)2 in GTP (JT-R 10/18/05)                         
+ 781 15 P+    0.9684   3.740     0.200      phosphonium R4P+                                        
+ 782 06 CT   -0.5081   3.500     0.066      CH3PR3+ 6-31G* CHELPG                                   
+ 783 06 CT   -0.0080   3.500     0.066      RCH2PR3+                                                
+ 784 01 HC    0.1720   2.500     0.030      H in CH3PR3+                                            
+ 785 15 P     1.3400   3.740     0.200      P in PF6-                                               
+ 786 09 F    -0.3900   3.1181    0.061      F in PF6-                                               
+ 787 07 N     0.794    3.150     0.170      N in NO3- F. van Veggel                                 
+ 788 08 O    -0.598    2.860     0.210      O in NO3- r(NO) =                                       
+ 789 06 CT    0.180    3.500     0.066      methoxy C in carbonate                                  
+ 790 06 CA    0.150    3.550     0.068      C(CF3) trifluoromethylbenzene test                      
+ 791 06 CF    0.450    3.250     0.062      CF3           " test                                    
+ 792 09 F    -0.200    2.940     0.061      F             " test                                    
+ 793 06 CA    0.380    3.550     0.068      C-ipso phenylguanidinium ion                            
+ 794 01 HC    0.030    2.500     0.030      H(COR): alpha H ether 2020 for CH3-O-R                  
+ 795 08 OW    0.0      3.270     0.1000     O TIP4F Water  Unpublished                              
+ 796 01 HW    0.511    0.0       0.0        H TIP4F Water      "                                    
+ 797 99 LP   -1.022    0.0       0.0        M TIP4F Water      "                                    
+ 798 06 CT    0.00     3.570     0.060      CH4    all-atom C: q = 0                                
+ 799 01 HC    0.00     2.480     0.026      H       all-atom H: q = 0                               
+ 800                                        800-899 reserved for QM/MM atoms - do not use - they    
+ 899                                        will be read from the Z-matrix file, not from here      
+ 900 07 NT   -0.900     3.300     0.170     N      primary   amines                                 
+ 901 07 NT   -0.780     3.300     0.170     N      secondary amines                                 
+ 902 07 NT   -0.630     3.300     0.170     N      tertiary  amines                                 
+ 903 06 CT    0.000     3.500     0.066     CH3(N) primary   aliphatic amines, H(C) type 911        
+ 904 06 CT    0.020     3.500     0.066     CH3(N) secondary aliphatic amines, H(C) type 911        
+ 905 06 CT    0.030     3.500     0.066     CH3(N) tertiary  aliphatic amines, H(C) type 911        
+ 906 06 CT    0.060     3.500     0.066     CH2(N) primary   aliphatic amines, H(C) type 911        
+ 907 06 CT    0.080     3.500     0.066     CH2(N) secondary aliphatic amines, H(C) type 911        
+ 908 06 CT    0.090     3.500     0.066     CH2(N) tertiary  aliphatic amines, H(C) type 911        
+ 909 01 H     0.360     0.0       0.0       H(N)   primary   amines                                 
+ 910 01 H     0.380     0.0       0.0       H(N)   secondary amines                                 
+ 911 01 HC    0.06      2.500     0.015     H(C) for Carbons directly bonded to N in amines, diamine
+ 912 06 CT    0.120     3.500     0.066     CH     primary isopropyl amine                          
+ 913 06 CT    0.180     3.500     0.066     C      primary t-butyl amine                            
+ 914 06 CT    0.140     3.500     0.066     CH     secondary isopropyl amine                        
+ 915 06 CT    0.150     3.500     0.066     CH     tertiary  isopropyl amine                        
+ 916 06 CA    0.180     3.550     0.068     C(NH2) aniline                                          
+ 917 06 CA    0.200     3.550     0.068     C(NHR) N-methylaniline                                  
+ 918 06 CA    0.210     3.550     0.068     C(NR2) N,N-dimethylaniline                              
+ 919 06 CT    0.115     3.500     0.066     C in CH2NH2 - benzyl amines; C(CH2NH2) is #221          
+ 920 06 CT    0.175     3.500     0.066     C in CHRNH2 - benzyl amines                             
+ 921 06 CT    0.235     3.500     0.066     C in CR2NH2 - benzyl amines                             
+ 922 06 CT    0.195     3.500     0.066     C in CH2OR  - benzyl ethers; C(CH2OR) is #221           
+ 923 06 CT    0.1525    3.500     0.066     C in CH2SR  - benzyl sulfides; C(CH2SR) is #221         
+ 924 06 CT    0.135     3.500     0.066     C in CH2NHR - benzyl amines; C(CH2NH2) is #221          
+ 925 06 CZ   -0.200     3.500     0.110     alkyne C%C - acetylene                     
+ 926 01 HC    0.200     2.420     0.015     alkyne RC%CH terminal H                                 
+ 927 06 CT    0.020     3.550     0.066     H3C-C%C                                                 
+ 928 06 CT    0.080     3.510     0.066     RCH2-C%C                                                
+ 929 06 CT    0.140     3.500     0.066     R2CH-C%C                                                
+ 930 06 CT    0.200     3.500     0.066     R3C-C%C                                                 
+ 931 06 CO    0.450     3.500     0.066     C1' of (ade, gua) by Deping                             
+ 932 06 CO    0.480     3.500     0.066     C1' of cyt by Deping                                    
+ 933 06 CO    0.510     3.500     0.066     C1' of (ura, thy) by Deping                             
+ 934 08 OH   -0.655     3.120     0.170     O5' by Deping                                           
+ 935 01 HO    0.390     0.0       0.0       H(3') OH by Deping                                      
+ 936 07 N*   -0.50      3.25      0.17      Adenine N9 Guanine nucleosides                          
+ 937 07 N*   -0.56      3.25      0.17      Cytosine N1 nucleoside                                  
+ 938 07 N*   -0.60      3.25      0.17      Uracil N1 Thymine nucleosides                           
+ 939 06 CZ    0.000     3.300     0.210     alkyne RC%CR - only did MC for MeCCMe                   
+ 940 07 N3   -0.10      3.480     0.290     N (R3NH+)                                               
+ 941 01 H3    0.29      0.0       0.0       H (R3NH+)                                               
+ 942 06 CT    0.090     3.500     0.066     C in  CH3NHR2+                                          
+ 943 06 CT    0.150     3.500     0.066     C in  RCH2NHR2+                                         
+ 944 06 CT    0.210     3.500     0.066     C in  R2CHNHR2+                                         
+ 945 06 CT    0.270     3.500     0.066     C in  R3CNHR2+                                          
+ 946 06 CW    0.096     3.550     0.070     C2  in 2-phenylfuran                                    
+ 947 06 CS   -0.039     3.550     0.076     C3  in 3-phenylfuran                                    
+ 948 06 C!    0.027     3.550     0.070     C2' in 2-phenylfuran                                    
+ 949 06 C!    0.011     3.550     0.070     C3' in 2-phenylfuran                                    
+ 950 01 HC    0.074     2.500     0.030     glycine zwit. 6-31G* CHELPG charges                     
+ 951 06 CT   -0.029     3.500     0.066     glycine zwit. 6-31G* CHELPG charges                     
+ 952 06 C     0.700     3.750     0.105     glycine zwit. 6-31G* CHELPG charges                     
+ 953 07 N3   -0.352     3.480     0.290     glycine zwit. 6-31G* CHELPG charges                     
+ 954 08 O2   -0.709     2.960     0.210     glycine zwit. 6-31G* CHELPG charges                     
+ 955 01 H3    0.317     0.0       0.0       glycine zwit. 6-31G* CHELPG charges                     
+ 956 09 F    -0.220     2.940     0.061     F  in monoalkyl fluorides tentative                     
+ 957 06 CT    0.020     3.500     0.066     RCH2F  "     "        tentative                         
+ 958 01 HC    0.100     2.500     0.030     H in RCHF             tentative                         
+ 959 06 CT    0.120     3.500     0.066     R2CHF  "     "        tentative                         
+ 960 06 CT    0.220     3.500     0.066     R3CF  "     "         tentative                         
+ 961 06 CF    0.36      3.500     0.066     CF3    perfluoroalkanes JPC A, 105, 4118                
+ 962 06 CF    0.24      3.500     0.066     CF2    perfluoroalkanes       "                         
+ 963 06 CF    0.12      3.500     0.066     CF     perfluoroalkanes       "                         
+ 964 06 CF    0.48      3.500     0.097     CF4                           "                         
+ 965 09 F    -0.120     2.950     0.053     F      F in perfluoroalkanes  "                         
+ 966 06 CT    0.250     3.250     0.062     CF2H   difluoromethylbenzene                            
+ 967 01 HC    0.150     2.500     0.030     H in CF2H     "                                         
+ 968 06 CT   -0.080     3.500     0.066     FCH2COO-  fluoroacetate tentative                       
+ 969 06 CT   -0.106     3.500     0.066     ClCH2COO- chloroacetate  "                              
+ 970 17 Cl   -0.200     3.400     0.300     Cl in alkyl chlorides repeat of 151                     
+ 971 06 CT   -0.006     3.500     0.066     RCH2Cl "     "                  152                     
+ 972 01 HC    0.103     2.500     0.030     H in RCHCl                      153                     
+ 973 06 CT    0.097     3.500     0.066     R2CHCl  "     "        tentative                        
+ 974 06 CT    0.200     3.500     0.066     R3CCl   "     "        tentative                        
+ 975 35 Br   -0.200     3.470     0.470     Br in alkyl bromides   JPCB 16264 (2004)                
+ 976 06 CT   -0.006     3.500     0.066     RCH2Br "     "            "                             
+ 977 01 HC    0.103     2.500     0.030     H in RCHBr                "                             
+ 978 06 CT    0.097     3.500     0.066     R2CHBr  "     "        tentative                        
+ 979 06 CT    0.200     3.500     0.066     R3CBr   "     "        tentative                        
+ 980 09 F    -0.080     2.940     0.061     F  in  acyl fluoride   tentative                        
+ 981 17 Cl   -0.080     3.400     0.300     Cl in  acyl chloride   tentative                        
+ 982 35 Br   -0.080     3.470     0.470     Br in  acyl bromide    tentative                        
+ 983 06 CA    0.100     3.550     0.068     C(OCF3): trifluoroanisole                               
+ 984 08 OS   -0.250     2.900     0.140     O: trifluoroanisole                                     
+ 985 06 CT    0.600     3.500     0.066     C in CF3: trifluoroanisole                              
+ 986 09 F    -0.150     2.900     0.060     F: trifluoroanisole                                     
+ 987 07 N    -0.025     3.250     0.170     N: N-methyl,N-phenylacetamide                           
+ 988 06 CA   -0.045     3.550     0.068     ipso C in N-methyl,N-phenylacetamide                    
+ 989 06 CT    0.145     3.500     0.066     C in CH2NR2 - benzyl amines; C(CH2NH2) is #221          
+ 990 06 C     0.888     3.750     0.105     C  in hydroxamic acid  jtr 11/98                        
+ 991 06 C     1.003     3.750     0.105     C  in aromatic hydroxamic aciT                          
+ 992 08 O    -0.658     2.960     0.210     O  in hydroxamic acid                                   
+ 993 07 N    -0.634     3.250     0.170     N  in hydroxamic acid                                   
+ 994 01 H     0.411     0.000     0.000     HN in hydroxamic acid                                   
+ 995 08 OH   -0.442     3.120     0.170     OH in hydroxamic acid                                   
+ 996 01 HO    0.435     0.000     0.000     HO in hydroxamic acid                                   
+ 997 06 CT    0.225     3.500     0.066     C in CHROR  - benzyl ethers; C(CHROR) is #221           
+ 998 06 CT    0.255     3.500     0.066     C in CRROR  - benzyl ethers; C(CRROR) is #221           
+ 999                                                                                                
+1000 06 C!   -0.034     3.550     0.070     3-phenyl pyrrole C3                                     
+1001 06 C!    0.003     3.550     0.070     3-phenyl pyrrole C3'                                    
+1002 06 C!    0.300     3.550     0.070     4-phenyl imidazole C4                                   
+1003 06 C!   -0.040     3.550     0.070     4-phenyl imidazole C4'                                  
+1004 06 CA  -0.0575     3.550     0.068     diphenylmethane Cipso                                   
+1005 30 Zn    2.0       1.960     0.0125    JACS 113, 8262 (1991)  Zinc                             
+#                                                                                                   
+#    Halogen Bonding - Jorgensen, W. L.; Schyman, P. JCTC 2012, 8, 3895-3901.
+1006 00 XC    0.075     0.0       0.0       chlorine plus site Jan 23, 2012                         
+1007 00 XB    0.100     0.0       0.0       bromine  plus site Jan 23, 2012                         
+1008 00 XI    0.110     0.0       0.0       iodine   plus site Jan 23, 2012                         
+1009 06 CA    0.175     3.550     0.068     C(Cl)  chlorobenzene with X site                        
+1010 17 Cl   -0.250     3.400     0.300     Cl     chlorobenzene with X site                        
+#                                                                                                   
+1011 06 CT   -0.070     3.500     0.066     C(I)  iodoalkane  - tentative - primary                 
+1012 06 CT    0.030     3.500     0.066     C(I)  iodoalkane  - tentative - secondary               
+1013 06 CT    0.130     3.500     0.066     C(I)  iodoalkane  - tentative - tertiary                
+1014 53 I    -0.130     3.750     0.600     I     iodoalkane  - tentative                           
+1015 01 HC    0.100     2.500     0.030     H in  RCHI                                              
+#                                                                                                   
+1016 06 CA    0.170     3.550     0.068     C(Br) bromobenzene with X site                          
+1017 35 Br   -0.270     3.470     0.470     Br    bromobenzene with X site                          
+1018 06 CA    0.150     3.550     0.068     C(I)  iodobenzene  with X site                          
+1019 53 I    -0.260     3.750     0.600     I     iodobenzene  with X site                          
+#                                                                                                   
+1020                                                                                                
+1021 07 N    -0.685    3.250     0.170      N of secondary N-phenyl sulfonamide                     
+1022 06 CA    0.155    3.550     0.068      benzene C on N of N-phenyl sulfonamide                  
+1023                                                                                                
+1024                                                                                                
+1025 08 O$   -0.400     2.900     0.140     O   epoxide  oxirane                                    
+1026 06 CY    0.140     3.500     0.066     CH2 epoxide                                             
+1027 06 CY    0.170     3.500     0.066     CH  epoxide                                             
+1028 06 CY    0.200     3.500     0.066     C   epoxide                                             
+1029 01 HC    0.030     2.500     0.030     H   epoxide on C-O                                      
+1030                                                                                                
+1031                                                                                                
+1032 06 CA   -0.100     3.550     0.068     ipso C in benzoate ion                                  
+1033 07 N    -0.427     3.250     0.170     N: N-phenylurea                                         
+1034 06 CA    0.218     3.550     0.068     ipso C in N-phenylurea                                  
+1035 06 C     0.600     3.750     0.105     C: C=O in tert amide.   Acyl R in amides                
+1036 08 O    -0.600     2.960     0.210     O: C=O in tert amide.   is neutral - use                
+1037 07 NM   -0.360     3.250     0.170     N: tertiary amide     JCC 25, 1322 (2004)               
+1038 06 CT    0.000     3.500     0.066     C on N: tertiary amide CH3                              
+1039 06 CT    0.060     3.500     0.066     C on N: tertiary amide CH2R                             
+1040 06 CT    0.120     3.500     0.066     C on N: tertiary amide CHR2                             
+1041 06 CT    0.180     3.500     0.066     C on N: tertiary amide CR3                              
+1042 01 HC    0.060     2.420     0.015     H on CT:tertiary amide                                  
+1043 06 C     0.570     3.750     0.105     C: C=O in tert formamide.                               
+1044 08 O    -0.570     2.960     0.210     O: C=O in tert formamide.                               
+1045 01 HC    0.000     2.420     0.015     H on CO:  tert formamide                                
+#--------- backbone atoms for Beta-3-Peptides (xc 1049) JT-R Nov'05, some from DW                   
+1046                                                                                                
+1047                                                                                                
+1048                                                                                                
+1049 06 CT    0.020     3.500     0.066     CH;  Calpha in beta-2-peptides                          
+1050 06 CT   -0.040     3.500     0.066     CH2; Calpha in all (M, N-ter)                           
+1051 06 CT    0.000     3.500     0.066     CH2; Cbeta in b-Gly (M, C-ter)                          
+1052 06 CT    0.060     3.500     0.066     CH;  Cbeta in most (M, C-ter)                           
+1053 06 CT   -0.070     3.500     0.066     CH;  Cbeta in b-Pro (M, C-ter)                          
+1054 06 CT   -0.140     3.500     0.066     CH2; Calpha for all (C-ter)                             
+1055 06 CT    0.170     3.500     0.066     CH;  Cbeta for most (N-ter)                             
+1056 06 CT    0.110     3.500     0.066     CH;  Cbeta for b-Gly (N-ter)                            
+1057 06 CT    0.150     3.500     0.066     CH;  Cbeta for b-Pro (N-ter)                            
+1058 06 CT    0.170     3.500     0.066     CH2; Cepsilon for b-Pro (N-ter)                         
+1059                                                                                                
+#---------       silicon - wlj unpublished                                                         
+1060 14 Si    0.320     4.00      0.10      Si in tetraalkylsilane R4Si                             
+1061 14 Si    0.250     4.00      0.10      Si in  R3SiH                                            
+1062 14 Si    0.180     4.00      0.10      Si in  R2SiH2                                           
+1063 14 Si    0.110     4.00      0.10      Si in  RSiH3                                            
+1064 01 H    -0.010     2.50      0.03      H   on Si in silane, silanol, silyl ether               
+1065 06 CT   -0.26      3.500     0.066     CH3 on Si in silane,   "                                
+1066 06 CT   -0.20      3.500     0.066     CH2 on Si in silane,   "                                
+1067 06 CT   -0.14      3.500     0.066     CH  on Si in silane,   "                                
+1068 06 CT   -0.08      3.500     0.066     C   on Si in silane,   "                                
+1069 06 CA   -0.08      3.550     0.070     C ipso in phenyl silane                                 
+1070 14 Si    0.39      4.00      0.10      Si in R3SiOH                                            
+1071 14 Si    0.32      4.00      0.10      Si in R2SiHOH                                           
+1072 14 Si    0.25      4.00      0.10      Si in RSiH2OH                                           
+1073 08 OH   -0.50      3.12      0.17      O in SiOH silanol                                       
+1074 01 HO    0.35      0.00      0.00      H in SiOH silanol                                       
+1075 14 Si    0.39      4.00      0.10      Si in R3SiOR  silyl ether                               
+1076 14 Si    0.32      4.00      0.10      Si in R2SiHOR     "                                     
+1077 14 Si    0.25      4.00      0.10      Si in RSiH2OR     "                                     
+1078 08 OS   -0.35      2.90      0.14      O: alkyl silyl ether - R on O is 181-185                
+1079 14 Si    0.24      4.00      0.10      Si in R3SiSi   disilane                                 
+1080 14 Si    0.17      4.00      0.10      Si in R2SiHSi  disilane                                 
+1081 14 Si    0.10      4.00      0.10      Si in RSiH2Si  disilane                                 
+1082 14 Si    0.03      4.00      0.10      Si in H3Si-Si  disilane                                 
+1083 14 Si    0.040     4.00      0.10      Si in  SiH4                                             
+1084 14 Si    0.18      4.00      0.10      Si in SiH3OH                                            
+1085                                                                                                
+1086                                                                                                
+1087                                                                                                
+1088                                                                                                
+1089                                                                                                
+1090                                                                                                
+1091                                                                                                
+1092                                                                                                
+1093                                                                                                
+1094                                                                                                
+1095                                                                                                
+1096 06 CA   -0.230    3.550     0.070      C in C5H5- cyclopentadienyl anion                       
+1097 01 HA    0.030    2.420     0.030      H in C5H5- cyclopentadienyl anion                       
+1098 06 CA   -0.099    3.550     0.070      C in C5H5  cyclopentadienyl radical                     
+1099 01 HA    0.099    2.420     0.030      H in C5H5  cyclopentadienyl radical                     
+1100 09 F    -1.0       3.08      0.72000   F-   1100-1114 provide                                  
+1101 17 Cl   -1.0       4.18      0.11779   Cl-  sigmas that yield the                              
+1102 35 Br   -1.0       4.51      0.09000   Br-  correct free energies                              
+1103 53 I    -1.0       5.15      0.07000   I-   of hydration for                                   
+1104                                             these ions using                                   
+1105                                                 GB/SA                                          
+1106 03 Li    1.00     2.70      0.018279   Li+  The epsilons are                                   
+1107 11 Na    1.00     3.35      0.002772   Na+  unchanged from                                     
+1108 19 K     1.00     4.06      0.000328   K+   400-414.                                           
+1109 37 Rb    1.00     4.32      0.000171   Rb+                                                     
+1110 55 Cs    1.00     4.82      0.000081   Cs+                                                     
+1111 12 Mg    2.00     2.91      0.875044   Mg++                                                    
+1112 20 Ca    2.00     3.47      0.449657   Ca++                                                    
+1113 38 Sr    2.00     3.82      0.118226   Sr++                                                    
+1114 56 Ba    2.00     4.18      0.047096   Ba++                                                    
+1115                                                                                                
+1116                                                                                                
+1117                                                                                                
+1118                                                                                                
+1119                                                                                                
+1120 06 CT   -0.050     3.500     0.066     C in  CH3NR3+    July 2005                              
+1121 06 CT    0.050     3.500     0.066     C in  RCH2NR3+   WLJ                                    
+1122 06 CT    0.150     3.500     0.066     C in  R2CHNR3+   ammonium                               
+1123 06 CT    0.250     3.500     0.066     C in  R3CNR3+                                           
+1124 01 HC    0.100     2.500     0.030     H in  CH3NR3+                                           
+1125 07 N3    0.115     3.480     0.290     N (ArNR3+)       Anilinium Ion                          
+1126 06 CA    0.135     3.550     0.068     Cipso (ArNR3+)                                          
+1127 07 N3    0.015     3.480     0.290     N (ArNR2H+)                                             
+1128 06 CA    0.155     3.550     0.068     Cipso (ArNR2H+)                                         
+1129                                                                                                
+1130                                                                                                
+1151 06 C#    0.000     3.550     0.076     triene C (R2-C=) central C=C                            
+1152 06 C#   -0.115     3.550     0.076     triene C (RH-C=) central C=C                            
+1153 01 HC    0.150     2.420     0.030     allene H                                                
+1154 06 CM   -0.250     3.300     0.086     allene C1 CH2                                           
+1155 06 CM   -0.100     3.300     0.086     allene C1 CHR                                           
+1156 06 CM    0.050     3.300     0.086     allene C1 CR2                                           
+1157 06 C:   -0.100     3.300     0.086     allene C2                                               
+1158 06 C:    0.200     3.300     0.086     ketene C2                                               
+1159 08 O    -0.250     2.960     0.210     ketene O                                                
+1160 06 C:    0.700     2.620    0.06762    CO2 Madura 2009 carbon dioxide                          
+1161 08 O    -0.350     2.930    0.188814   CO2 Madura 2009                                         
+1162                                                                                                
+1200 06 CT    0.088    3.500     0.066      CB in N-Me HIS                                          
+1233 16 SA    0.000    3.600     0.355      S   thiazole jlj0003 OPLS-AA/L                          
+1234 06 CR    0.350    3.550     0.070      C2  thiazole jlj0003                                    
+1235 07 NB   -0.400    3.250     0.170      N   thiazole jlj0003                                    
+1236 06 CV    0.000    3.550     0.070      C4  thiazole jlj0003                                    
+1237 06 CW   -0.150    3.550     0.070      C5  thiazole jlj0003                                    
+1239 01 HA    0.200    2.420     0.030      H4  thiazole jlj0003                                    
+1240 01 HA    0.200    2.420     0.030      H5  thiazole jlj0003                                    
+1241                                                                                                
+1260 06 CT   0.1263     3.500     0.066     CH2 Trifluoroethanol TFE                                
+1261 06 CT   0.5323     3.250     0.062     CF3  E Duffy Thesis 1994                                
+1262 08 OH  -0.6351     3.070     0.170     OH            "                                         
+1263 01 HO   0.4286     0.00      0.000     HO            "                                         
+1264 09 F   -0.2057     2.940     0.061     F             "                                         
+1265 01 HC   0.0825     2.500     0.030     H             "                                         
+1266
+1268 06 CY   -0.005     3.430     0.088     CHCH=CH2 vinylcyclopropane OPLS-2020                        
+1269 06 CM   -0.170     3.550     0.076     vinylcyclopropane                                       
+1270 06 CY    0.080     3.430     0.088     CHC%CH ethynylcyclopropane OPLS-2020                        
+1271 06 CZ   -0.140     3.500     0.110     ethynylcyclopropane                     
+#                                                                                                   
+#    Add more charge and L-J parameters above this point.                                           
+#                                                                                                   
+#          Summary of OPLS-AA Atom Types for Amino Acids                                            
+#                                                                                                   
+#    Backbone entries are:                                                                          
+#     Atom                                Type                                                      
+#    amide C                              235                                                       
+#    amide O                              236                                                       
+#    Calpha in Gly                        223                                                       
+#    Calpha in Pro                        246                                                       
+#    Calpha in Ala, etc.                  224                                                       
+#    Calpha in Aib                        225                                                       
+#    H-Calpha in all AA                   140                                                       
+#    N sec-amide; all AA except Pro       238                                                       
+#    N tert-amide; Pro                    239                                                       
+#    H-N in all AA                        241                                                       
+#                                                                                                   
+#    Side-chain entries are:                                                                        
+#   H on any saturated C  is type 140                                                               
+#   H on any sp2 C is type 146                                                                      
+#    AA   Atom    Type      AA   Atom    Type     AA   Atom    Type                                 
+#    Ala   CB     135       Aib   CB     135                                                        
+#    Val   CB     137       Val   CG     135                                                        
+#    Leu   CB     136       Leu   CG     137      Leu   CD     135                                  
+#    Ile   CB     137       Ile   CG1    135      Ile   CG2    136                                  
+#    Ile   CD2    135                                                                               
+#    Pro   CB     136       Pro   CG     136      Pro   CD     245                                  
+#    Phe   CB     149       Phe  CG-CZ   145                                                        
+#    Ser   CB     157       Ser   OG     154      Ser   HO     155                                  
+#    Thr   CB     158       Thr   OG     154      Thr   HO     155                                  
+#    Thr   CG     135                                                                               
+#    Tyr   CB     149       Tyr  CG-CE   145      Tyr   CZ     166                                  
+#    Tyr   O      167       Tyr   HO     168                                                        
+#    Trp   CB     136       Trp   CG     500      Trp  CD (CH) 145                                  
+#    Trp   CD (C) 501       Trp   NE     503      Trp  HN      504                                  
+#    Trp   CE (C) 502       Trp other CH 145                                                        
+#    Cys   CB     206       Cys   SG     200      Cys  HS      204                                  
+#    Cyx   CB     214       Cyx   SG     203                                                        
+#    Met   CB     136       Met   CG     210      Met  SD      202                                  
+#    Met   CE     209                                                                               
+#    Asp   CB     274       Asp   CG     271      Asp  OD      272                                  
+#    Glu   CB     136       Glu   CG     274      Glu  CD      271                                  
+#    Glu   OE     272                                                                               
+#    Asn   CB     136       Asn   CG     235      Asn  OD      236                                  
+#    Asn   ND     237       Asn   HN     240                                                        
+#    Gln   CB     136       Gln   CG     136      Gln  CD      235                                  
+#    Gln   OE     236       Gln   NE     237      Gln  HN      240                                  
+#    Lys CB-CD    136       Lys   CE     292      Lys  NZ      287                                  
+#    Lys   HN     290                                                                               
+#    Arg   CB     136       Arg   CG     308      Arg  CD      307                                  
+#    Arg   NE     303       Arg   HNE    304      Arg  CZ      302                                  
+#    Arg   NN     300       Arg   HNN    301                                                        
+#    Hid   CB     505       Hid   CG     508      Hid  ND1     503                                  
+#    Hid   HND    504       Hid   CE1    506      Hid  HE      146                                  
+#    Hid   NE2    511       Hid   CD2    507      Hid  HD      146                                  
+#    Hie   CB     505       Hie   CG     507      Hie  ND1     511                                  
+#    Hie   CE1    506       Hie   HE     146      Hie  NE2     503                                  
+#    Hie   HNE    504       Hie   CD2    508      Hie  HD      146                                  
+#    Hip   CB     505       Hip   CG     510      Hip  ND1     512                                  
+#    Hip   HND    513       Hip   CE1    509      Hip  HE      146                                  
+#    Hip   NE2    512       Hip   HNE    513      Hip  CD2     510                                  
+#    Hip   HD     146                                                                               
+      Do not modify this & next 2 lines (for BOSS)                                                  
+      The following are the Fourier coefficients for dihedral angles - ALL ATOM.                    
+Type   V1         V2        V3        V4               description                                  
+001   0.000     0.000     0.300     0.0        HC-CT-CT-HC     hydrocarbon  11/99              
+001   0.000     0.000     0.300     0.0        HC-C -C -HC                                          
+001   0.000     0.000     0.300     0.0        HC-C=-C=-HC                                          
+001   0.000     0.000     0.300     0.0        HC-C=-C#-HC                                          
+001   0.000     0.000     0.300     0.0        HC-C=-C#-CT                                          
+001   0.000     0.000     0.300     0.0        CT-C=-C#-CT                                          
+001   0.000     0.000     0.300     0.0        CT-C=-C=-CT                                          
+001   0.000     0.000     0.300     0.0        CT-C=-C=-HC                                          
+001   0.000     0.000     0.300     0.0        CT-C#-C=-CT                                          
+001   0.000     0.000     0.300     0.0        CT-C#-C=-HC                                          
+001   0.000     0.000     0.300     0.0        H3-N3-CT-HC     ammonium                             
+001   0.000     0.000     0.300     0.0        HC-CT-CT-CT     hydrocarbon                          
+001   0.000     0.000     0.300     0.0        HC-CM-CT-CT     hydrocarbon                          
+001   0.0       0.0       0.300     0.0        HC-CT-CT-OH     alcohols, ethers OPLS/2020           
+001   0.0       0.0       0.300     0.0        HC-CT-CT-OS     alcohols, ethers AA                  
+001   0.0       0.0       0.300     0.0        HC-CT-CO-OS     alcohols, ethers AA                  
+001   0.0       0.0       0.300     0.0        HC-CM-CT-O?     alcohols, ethers AA                  
+002   0.000     0.000     0.300     0.0        HC-CT-CT-CO     acetal                               
+002   0.000     0.000     0.300     0.0        HC-CO-CT-CT     acetal                               
+003   0.850    -0.200     0.200     0.0        CT-CT-CT-CT     hydrocarbon OPLS/2020                
+003   0.850    -0.200     0.200     0.0        CT-CT-CT-CO     hydrocarbon OPLS/2020                
+004   1.100    -0.200     0.200     0.0        CT-CT-CT-CT     butane only OPLS/2020                
+005   2.0      -0.20     0.0       0.0         CT-CT-CT-OH     alcohols         OPLS/2020           
+006   1.3      -0.50     0.0       0.0         CT-CT-CT-OS     ethers           OPLS/2020           
+006   1.3      -0.50     0.0       0.0         CT-CT-CT-O?     alcohols, ethers OPLS/2020           
+006   1.3      -0.50     0.0       0.0         CT-CT-CO-O?     alcohols, ethers OPLS/2020           
+006   1.3      -0.50     0.0       0.0         CT-CM-CT-O?     alcohols, ethers AA                  
+007  -1.552     0.0      0.000     0.0         CT-CT-CT-OH     polyols  AA                          
+008   0.0       0.0      0.3524    0.0         HC-CT-OH-HO     alcohols AA 5/02 modified from 0.45  
+009  -0.5       0.2       0.3       0.0        CT-CT-OH-HO     alcohols OPLS/2020                   
+010   9.508     0.00      0.000     0.0        OH-CT-CT-OH     diols only  AA                       
+011  12.234     0.00      0.000     0.0        OH-CT-CT-OH     triols only AA                       
+012   0.0       0.0       0.76      0.0        HC-CT-OS-C?     ethers AA                            
+012   0.0       0.0       0.76      0.0        HC-CT-OS-CA     ethers AA                            
+012   0.0       0.0       0.76      0.0        HC-CT-OS-CM     ethers AA                            
+012   0.0       0.0       0.76      0.0        HC-CM-OS-CT     ethers AA                            
+012   0.0       0.0       0.76      0.0        HC-CO-OS-CT     ethers AA                            
+012   0.0       0.0       0.76      0.0        HC-CT-OS-CO     ethers AA                            
+013   0.250    -0.25      0.500     0.0        CT-OS-CT-CT     ethers AA OPLS/2020                  
+013   0.250    -0.25      0.500     0.0        CT-OS-CM-CT     ethers AA OPLS/2020                  
+013   0.250    -0.25      0.500     0.0        CT-OS-CO-CT     ethers AA OPLS/2020                  
+014  -0.521    -2.018     1.996     0.0        CT-OS-CT-O?     acetals AA (Sugars:see 150-155)      
+015   8.000     0.0       0.0       0.0        NT-CT-CT-OH     2-aminoethanol 6-31G* fit - wj       
+016  -0.550     0.0       0.0       0.0        OS-CT-CT-OS     polyethers, crown ethers             
+017   0.0       3.37      0.0       0.30       CT-OS-CA-CA     anisole JT-R 2014/04 fit to MP2/aug-c
+017   0.0       3.37      0.0       0.30       CT-OS-CW-CS      - JT-R 2014/04 added for 2-MeOPyrrol
+018   0.0       0.0       0.0       0.0        CA-CA-CM-HC     styrene - generic - JT-R remove V3 - 
+018   0.0       0.0       0.0       0.0        CA-CA-C=-HC     styrene - generic - JT-R remove V3 - 
+018   0.0       0.0      -0.372     0.0        CM-C=-C=-CT     diene - generic                      
+018   0.0       0.0      -0.372     0.0        CM-C=-C=-HC     diene - generic                      
+018   0.0       0.0      -0.372     0.0        HC-C=-N=-C      azadiene                             
+018   0.0       0.0      -0.372     0.0        CM-C=-C#-HC     triene - generic                     
+018   0.0       0.0      -0.372     0.0        C#-C#-C=-HC     triene - generic                     
+018   0.0       0.0      -0.372     0.0        C#-C#-C=-CT     triene - generic                     
+018   0.0       0.0      -0.372     0.0        CM-C=-C#-CT     triene - generic                     
+018   0.0       0.0      -0.372     0.0        CA-CA-C#-HC     triene - generic                     
+019   1.423     4.055     0.858     0.0        CM-C=-C=-CM     diene C=C-C=C                        
+019   1.423     4.055     0.858     0.0        C#-C#-C=-CM     triene C=C-C=C                       
+019   1.423     4.055     0.858     0.0        C#-C#-C#-C#     polyene C=C-C=C                      
+020   0.000     0.000     0.000     0.0        CT-CT-CT-CA     alkyl benzenes                       
+020   0.000     0.000     0.000     0.0        HC-CT-CA-CA     ethyl benzene, toluene               
+020   0.000     0.000     0.000     0.0        HC-CO-CA-CA     phenylacetal                         
+020   0.000     0.000     0.000     0.0        HC-CY-CA-CA     cyclopropylbenzene  11/10            
+020   0.000     0.000     0.000     0.0        HC-CY-CA-NC     cyclopropylpyridine 11/10            
+020   0.000     0.000     0.000     0.0        HC-CY-CW-NA     cyclopropylpyrrole - JT-R 2014/04    
+020   0.000     0.000     0.000     0.0        HC-CY-CW-OA     cyclopropylfuran - JT-R 2014/04      
+020   0.000     0.000     0.000     0.0        HC-CM-CA-NC     vinylpyridine - JT-R 2014/04         
+020   0.000     0.000     0.000     0.0        HC-C=-CA-NC     vinylpyridine - JT-R 2014/04         
+020   0.000     0.000     0.000     0.0        HC-CM-CP-SA     vinylthiophene - JT-R 2014/04        
+020   0.000     0.000     0.000     0.0        HC-C=-CP-SA     vinylthiophene - JT-R 2014/04        
+020   0.000     0.000     0.000     0.0        CA-CA-Cl-XC     halogen bond                         
+020   0.000     0.000     0.000     0.0        CA-CA-Br-XB     halogen bond                         
+020   0.000     0.000     0.000     0.0        CA-CA-I -XI     halogen bond                         
+020   0.000     0.000     0.000     0.0        ??-C?-Cl-XC     halogen bond                         
+020   0.000     0.000     0.000     0.0        ??-C?-Br-XB     halogen bond                         
+020   0.000     0.000     0.000     0.0        ??-C?-I -XI     halogen bond                         
+020   0.000     0.000     0.000     0.0        H3-N3-CA-CA     anilinium                            
+020   0.000     0.000     0.000     0.0        HC-CT-CW-??     aromatics                            
+020   0.000     0.000     0.000     0.0        HC-CT-CP-??     aromatics                            
+020   0.000     0.000     0.000     0.0        HC-CT-CV-??     aromatics                            
+020   0.000     0.000     0.000     0.0        HC-CT-CR-??     aromatics                            
+020   0.000     0.000     0.000     0.0        HC-CT-CS-??     aromatics                            
+020   0.000     0.000     0.000     0.0        HC-CT-CQ-??     aromatics                            
+020   0.000     0.000     0.000     0.0        HC-CT-CU-??     aromatics                            
+020   0.000     0.000     0.000     0.0        HC-CT-CK-??     aromatics                            
+020   0.000     0.000     0.000     0.0        HC-CT-C*-??     aromatics                            
+020   0.000     0.000     0.000     0.0        CZ-CZ-CM-HC     enynes                               
+020   0.000     0.000     0.000     0.0        CZ-CZ-CM-CT     enynes                               
+021   0.000     0.000     0.000     0.0        CT-N3-CA-CA     anilinium ion                        
+021   0.000     0.000     0.000     0.0        CT-CT-CW-??     aromatics                            
+021   0.000     0.000     0.000     0.0        CS-CW-CT-CT     aromatics   JT-R 2014/04 added to pre
+021   0.000     0.000     0.000     0.0        CT-CT-CV-??     aromatics                            
+021   0.000     0.000     0.000     0.0        CT-CT-CR-??     aromatics                            
+021   0.000     0.000     0.000     0.0        CT-CT-CS-??     aromatics                            
+021   0.000     0.000     0.000     0.0        CT-CT-CQ-??     aromatics                            
+021   0.000     0.000     0.000     0.0        CT-CT-CU-??     aromatics                            
+021   0.000     0.000     0.000     0.0        CT-CT-CK-??     aromatics                            
+021   0.000     0.000     0.000     0.0        CT-CT-C*-??     aromatics                            
+021   0.000     0.000     0.000     0.0        O?-CT-CA-CA     benzyl alcohols & ethers             
+021   0.000     0.000     0.000     0.0        C?-CT-NA-C?     heterocycles                         
+021   0.000     0.000     0.000     0.0        H?-CT-NA-C?     heterocycles                         
+021   0.000     0.000     0.000     0.0        HC-CT-NS-CW     heterocycles                         
+021   0.000     0.000     0.000     0.0        C?-CT-N*-C?     heterocycles                         
+021   0.000     0.000     0.000     0.0        H?-CT-N*-C?     heterocycles                         
+021   0.000     0.000     0.000     0.0        O -C -CR-O?     heterocycles                         
+021   0.000     0.000     0.000     0.0        O -C -CR-N?     heterocycles                         
+021   0.000     0.000     0.000     0.0        CA-CA-CT-N?     aromatics                            
+021   0.000     0.000     0.000     0.0        CA-CA-CO-O?     aromatics                            
+021   0.000     0.000     0.000     0.0        CA-CA-CT-O?     aromatics                            
+021   0.000     0.000     0.000     0.0        NB-CV-CT-C      VHL_3                                
+021   0.000     0.000     0.000     0.0        CW-CV-CT-C      VHL_3                                
+021   0.000     0.000     0.000     0.0        ??-Zn-N -??     JACS 113, 8262 (91)                  
+021   0.000     0.000     0.000     0.0        ??-Zn-O -??     JACS 113, 8262 (91)                  
+022   0.000     0.000     0.462     0.0        HC-CT-CT-CA     ethyl benzene                        
+022   0.000     0.000     0.462     0.0        HC-CT-N3-CA     anilinium                            
+022   0.000     0.000     0.462     0.0        HC-CT-CT-CW     aromatics                            
+022   0.000     0.000     0.462     0.0        HC-CT-CT-CV     aromatics                            
+022   0.000     0.000     0.462     0.0        HC-CT-CT-CR     aromatics                            
+022   0.000     0.000     0.462     0.0        HC-CT-CT-CS     aromatics                            
+022   0.000     0.000     0.462     0.0        HC-CT-CT-CQ     aromatics                            
+022   0.000     0.000     0.462     0.0        HC-CT-CT-CU     aromatics                            
+022   0.000     0.000     0.462     0.0        HC-CT-CT-CK     aromatics                            
+022   0.000     0.000     0.462     0.0        HC-CT-CT-C*     aromatics                            
+023   0.000    -7.414     1.705     0.0        CT-S -S -CT     disulfide all-atom                   
+024   0.000     0.000     0.558     0.0        HC-CT-S -S      disulfide all-atom                   
+025   1.941    -0.836     0.935     0.0        CT-CT-S -S      disulfide all-atom                   
+026   0.000     0.000     0.480     0.0        HC-CT-SH-HS     thiol all-atom  (mod 11/99)          
+027  -0.759    -0.282     0.680     0.0        CT-CT-SH-HS     thiol all-atom  (mod 11/99)          
+028   0.000     0.000     0.452     0.0        HC-CT-CT-SH     thiol all-atom                       
+028   0.000     0.000     0.452     0.0        HC-CT-CT-SY                                          
+028   0.000     0.000     0.452     0.0        HC-CT-CT-S      sulfide all-atom                     
+029   1.262    -0.198     0.465     0.0        CT-CT-CT-SH     thiol all-atom  (mod 11/99)          
+029   1.262    -0.198     0.465     0.0        CT-CT-CT-SY                     (mod 11/99)          
+030   0.000     0.000     0.400     0.0        HC-CT-NT-H      amine all-atom See also 198.         
+031  -1.013    -0.709     0.473     0.0        HC-CT-CT-NT     amine all-atom                       
+032  -0.190    -0.417     0.418     0.0        CT-CT-NT-H      amine all-atom See 197.              
+032  -0.190    -0.417     0.418     0.0        CT-CT-N2-H      guanidinium                          
+032  -0.190    -0.417     0.418     0.0        CT-CT-N2-H3     guanidinium                          
+033   2.392    -0.674     0.550     0.0        CT-CT-CT-NT     amine all-atom                       
+034   0.000     2.060     0.000     0.0        HO-OH-CA-CA     phenol all-atom  JT-R 2014/04 AA+CM1A
+034   0.000     2.060     0.000     0.0        HO-OH-CW-CS     JT-R 2014/04 added for 2-hydroxy pyrr
+034   0.000     2.060     0.000     0.0        HO-OH-CP-CS     JT-R 2014/04 added for 2-hydroxy thio
+034   0.000     1.682     0.000     0.0        HO-OH-CM-CM       enol all-atom                      
+035   1.572     0.159     0.200     0.0        N -CT-CT-CT     Chi-1 Leu OPLS-AA/M                  
+036  -2.511     0.210    -0.200     0.0        C -N -CT-C      Phi  peptides AA/M                   
+037   1.810     2.155    -0.470     0.0        N -CT-C -N      Psi  peptides AA/M                   
+038  -0.682     0.130     0.338     0.0        C -N -CT-CT     Phi' peptides AA/M                   
+039   1.779     0.419    -0.110     0.0        CT-CT-C -N      Psi' peptides AA/M                   
+040   0.0       0.0       0.0       0.0        C -N -CT-HC     Phi" peptides AA                     
+041   0.000     0.000     0.000     0.0        HC-CT-C -N      Psi" peptides AA, all amides         
+041   0.000     0.000     0.000     0.0        HC-CM-C -N                                           
+041   0.000     0.000     0.000     0.0        HC-CT-C -NM                                          
+041   0.000     0.000     0.000     0.0        HC-CM-C -NM                                          
+041   0.000     0.000     0.000     0.0        CQ-N -CT-CT                                          
+041   0.000     0.000     0.000     0.0        CQ-N -CT-CA                                          
+042   0.000     0.000     0.000     0.0        H -N -CT-??     peptides                             
+042   0.000     0.000     0.000     0.0        H -N -CT-CT     peptides                             
+042   0.000     0.000     0.000     0.0        H -N -CT-C      peptides                             
+043   0.000     0.000     0.000     0.0        ??-CT-C -O      peptides                             
+043   0.000     0.000     0.000     0.0        CT-CT-C -O      peptides                             
+043   0.000     0.000     0.000     0.0        N -CT-C -O      peptides                             
+044   0.000     4.900     0.000     0.0        CT-C -N -H      amides                               
+044   0.000     4.900     0.000     0.0        CA-C -N -H      amides                               
+044   0.000     4.900     0.000     0.0        CS-C -N -H      amides 6/8/06                        
+044   0.000     4.900     0.000     0.0        CM-C -N -H      amides                               
+044   0.000     4.900     0.000     0.0        HC-C -N -H      amides                               
+044   0.000     4.900     0.000     0.0        CT-C -NM-CT     tert. amides 2/29/04                 
+044   0.000     4.900     0.000     0.0        O -C -NM-CT     tert. amides 2/29/04                 
+045   2.300     6.089     0.000     0.0        CT-C -N -CT     amides - V1 changed to 2.3           
+045   2.300     6.089     0.000     0.0        CT-C -N -CA                                          
+045   2.300     6.089     0.000     0.0        HC-C -N -CT     amides - V1 changed to 2.3           
+045   2.300     6.089     0.000     0.0        CA-C -N -CA     6/8/06                               
+045   2.300     6.089     0.000     0.0        CS-C -N -CA     6/8/06                               
+045   2.300     6.089     0.000     0.0        CA-C -N -CS     6/8/06                               
+045   2.300     6.089     0.000     0.0        CS-C -N -CS     6/8/06                               
+045   2.300     6.089     0.000     0.0        CW-C -N -CA     6/8/06                               
+045   2.300     6.089     0.000     0.0        CA-C -N -CW     6/8/06                               
+045   2.300     6.089     0.000     0.0        CW-C -N -CW     6/8/06                               
+045   2.300     6.089     0.000     0.0        CS-C -N -CW     6/8/06                               
+045   2.300     6.089     0.000     0.0        CW-C -N -CS     6/8/06                               
+046   0.000     4.900     0.000     0.0        O -C -N -H      amides   wlj 6/20/97                 
+047   0.000     6.089     0.000     0.0        O -C -N -CT     amides                               
+047   0.000     6.089     0.000     0.0        O -C -N -CA     amides                               
+047   0.000     6.089     0.000     0.0        NC-C -N -CA     quanidine 11/10                      
+047   0.000     6.089     0.000     0.0        O -C -N -CM     amides                               
+044   0.000     4.900     0.000     0.0        N -C -N -H      imides                               
+045   2.300     6.089     0.000     0.0        N -C -N -C      imides                               
+048   0.000     0.000     0.000     0.0        CT-N -CT-HC     tert. amide                          
+048   0.000     0.000     0.000     0.0        CT-N2-CT-HC     tert. amide                          
+048   0.000     0.000     0.000     0.0        CA-N -CT-HC      "                                   
+048   0.000     0.000     0.000     0.0        CT-NM-CT-HC     tert. amide                          
+048   0.000     0.000     0.000     0.0        CA-NM-CT-HC      "                                   
+049   0.000     0.610     0.000     0.0        CA-CA-SH-HS     aromatic thiol JT-R 2014/04 AA/CM1A f
+049   0.000     0.610     0.000     0.0        C?-CA-SH-HS     aromatic thiol                       
+049   0.000     0.610     0.000     0.0        CS-CW-SH-HS     aromatic thiol                       
+049   0.000     0.610     0.000     0.0        CS-CP-SH-HS     aromatic thiol                       
+050   0.850     2.660     0.000     0.0        N?-CA-SH-HS     2-thiopyridine, JT-R 2014/04 AA/CM1A 
+051   0.000     0.000     0.647     0.0        HC-CT-S -CT     sulfide all-atom                     
+051   0.000     0.000     0.647     0.0        HC-CT-S -CA     sulfide all-atom                     
+052  -1.565    -0.009    -0.450     0.0        CT-CT-CT-S      sulfide all-atom, Met OPLS-AA/M      
+053   0.925    -0.576     0.677     0.0        CT-CT-S -CT     sulfide all-atom                     
+054   0.000     3.900     0.000     0.0        H -N2-CA-N2     guanidinium ion                      
+054   0.000     3.900     0.000     0.0        H -N2-CA-CA     guanidinium ion                      
+055   0.000     7.936     0.000     0.0        CT-N2-CA-N2     methylguanidinium ion                
+056   0.000     0.000     0.177     0.0        HC-CT-N2-CA     methylguanidinium ion                
+057   0.000     0.000     0.000     0.0        HC-CT-N2-H      methylguanidinium ion                
+058   1.829     0.243    -0.498     0.0        CT-CT-N2-CA     ethylguanidinium ion                 
+059   0.000     0.000    -0.582     0.0        HC-CT-CT-N2     ethylguanidinium ion                 
+060   0.000     0.000    -0.139     0.0        C -N -CT-HC     N-methylformamide                    
+060   0.000     0.000    -0.139     0.0        C -NM-CT-HC     tertiary amide                       
+061   0.000     0.000     0.000     0.0        HC-CT-N -H      N-methylformamide                    
+062  -1.396    -0.427     0.000     0.0        C -N -CT-CT     N-ethylformamide                     
+063   0.000     0.000     0.000     0.0        H -N -CT-CT     N-ethylformamide                     
+064   0.000     0.000     0.464     0.0        N -CT-CT-HC     N-ethylformamide                     
+065   1.964     0.000     0.659     0.0        N -CT-CT-CT     N-propylformamide                    
+062  -1.396    -0.427     0.000     0.0        C -NM-CT-CT     tertiary amide                       
+064   0.000     0.000     0.464     0.0        NM-CT-CT-HC     tertiary amide                       
+065   1.964     0.000     0.659     0.0        NM-CT-CT-CT     tertiary amide                       
+066   2.000     0.000     0.0       0.0        CM-CM-C -NM     tertiary amide                       
+066   2.000     0.000     0.0       0.0        CM-CM-C -N      vinyl amides                         
+067   0.000     0.000     0.000     0.0        HC-CT-C -O      all carbonyls                        
+067   0.000     0.000     0.000     0.0        HC-C -C -O                                           
+067   0.000     0.000     0.000     0.0        HC-CM-C -O                                           
+068   2.844    -0.361    -0.325     0.0        CT-CT-C -N      propanamide OPLS-AA/M                
+069   0.406     1.304     0.139     0.0        CT-CT-C -O      propanamide OPLS-AA/M                
+070   0.000     0.000    -0.100     0.0        HC-CT-CT-C      all carbonyls                        
+071  -2.060    -0.313     0.315     0.0        C -CT-CT-CT     butanamide                           
+072   6.258    -1.037     1.367     0.0        N -CT-CT-OH     Chi-1 for Ser & Thr OPLS-AA/M        
+073  -9.000     2.000     0.800     0.0        N -CT-CT-C      Central (phi) torsion for beta-3-pept
+074  -5.793     0.405     0.000     0.0        C -CT-CT-OH     Chi-1 for Ser & Thr OPLS-AA/M        
+075   1.130    -1.420     0.440     0.0        C -N -CT-CT     first (theta) torsion for beta-3-pept
+076   2.055     0.529     0.544     0.0        N -CT-CT-S?     Chi-1 for Cys OPLS-AA/M              
+077   3.260     0.440     0.600     0.0        CT-CT-C -N      lastl (psi) torsion for beta-3-peptid
+078  -3.323     0.529     0.000     0.0        C -CT-CT-S?     Chi-1 for Cys OPLS-AA/M              
+079   0.0       0.0       0.100     0.0        NC-CA-CT-HC     2-methylpyridine JT-R 2014/04 fit AA 
+080   0.000     0.000    -0.480     0.0        HC-CT-C*-CW     3-methylindole                       
+081   0.000     0.000     0.000     0.0        HC-CT-C*-CB     3-methylindole                       
+082  -0.714     0.000     0.000     0.0        CT-CT-C*-CW     3-ethylindole                        
+083   0.000     0.000     0.000     0.0        CT-CT-C*-CB     3-ethylindole                        
+084   0.000     0.000     0.419     0.0        HC-CT-CC-N?     HID, HIE, HIP, 5-ethylimidazole      
+085   2.366    -0.262     0.505     0.0        CT-CT-CC-N?       "                                  
+086   0.000     0.000     0.261     0.0        HC-CT-N3-H      ammonium ion all-atom                
+087   0.000     0.000     0.347     0.0        CT-CT-N3-H      ammonium ion all-atom                
+088   0.000     0.000     0.384     0.0        HC-CT-CT-N3     ammonium ion all-atom                
+089   2.732    -0.229     0.485     0.0        CT-CT-CT-N3     ammonium ion all-atom                
+090   0.000     0.000     0.000     0.0        HC-CT-NO-ON     nitro compounds                      
+091   0.000     0.820     0.000     0.0        ?T-CT-C -O      carboxylate ?=C,N                    
+091   0.000     0.820     0.000     0.0        ?T-CT-C -O2     carboxylate ?=C,N                    
+092   0.000     0.000    -0.225     0.0        HC-CT-CT-NO     nitroethane                          
+093  -3.185    -0.825     0.493     0.0        CT-CT-CT-C      carboxylate ion                      
+094   0.0       0.0       0.0       0.0        HC-CT-C -O2     caboxylates                          
+094   0.0       0.0       0.0       0.0        HC-CT-C -OH     acids                                
+095   0.000     0.546     0.000     0.0        CT-CT-C -O      RCOOH acid                           
+095   0.000     0.546     0.000     0.0        CA-CT-C -O      RCOOH acid                           
+096   1.000     0.546     0.450     0.0        CT-CT-C -OH     RCOOH acid                           
+097   5.260     0.820     0.0       0.0        NT-CT-C -OH     neutral amino acid                   
+098  -2.589    -1.123     0.270     0.0        HC-CT-OH-HO     axial cyclohexanol                   
+099   0.000     3.692     0.000     0.0        HO-OH-CA-NC     2-hydroxypyridine - JT-R 2014/04 fit 
+100   0.0       0.0       0.0       0.0              Dummy      Leave Blank                         
+101  -0.550     0.000     1.000     0.0        C -CT-CT-C      dicarboxylic acid                    
+102   0.000     5.500     0.00      0.0        O -C -OH-HO     carboxylic acid - aliphatic          
+103   1.500     5.500     0.00      0.0        CT-C -OH-HO     carboxylic acid - aliphatic          
+103   1.500     5.500     0.00      0.0        HC-C -OH-HO     carboxylic acid - aliphatic          
+104   0.0       0.0       0.074     0.0        C -CT-CT-HC     dicarboxylic acid                    
+105  -0.750    -0.550    -0.250     0.0        CT-CT-C -O      dicarboxylic acid                    
+106   0.0       1.412     0.00      0.0        CT-CT-C -OH     dicarboxylic acid                    
+107  -1.737     1.251    -3.501     0.0        CT-N -CT-C      Proline phi  CD-N-CA-C (fit to AM1)  
+108   4.753    -0.734     0.00      0.0        CT-N -CT-CT     "            CD-N-CA-CB JT-R 2/10/97 
+109   2.859     2.058    -11.266    0.0        CT-CT-N -CT     "       chi4 CG-CD-N-CA              
+107  -1.737     1.251    -3.501     0.0        CT-NM-CT-C                                           
+108   4.753    -0.734     0.00      0.0        CT-NM-CT-CT                                          
+109   2.859     2.058    -11.266    0.0        CT-CT-NM-CT                                          
+110   0.0      -1.0       0.00      0.0        CT-CT-C+-CT     carbocation                          
+110   0.0      -1.0       0.00      0.0        CT-CT-C+-HC     carbocation                          
+111   0.0       0.0       0.275     0.0        HC-CT-C -CT     ketone                               
+111   0.0       0.0       0.275     0.0        HC-CT-C -CA     ketone                               
+112   0.0       0.0       0.360     0.0        HC-CT-C -HC     aldehyde                             
+112   0.0       0.0       0.360     0.0        HC-CT-C -F      acyl halide                          
+112   0.0       0.0       0.360     0.0        HC-CT-C -Cl     acyl halide                          
+112   0.0       0.0       0.360     0.0        HC-CT-C -Br     acyl halide                          
+113   0.0       0.0       0.0       0.0        CT-CT-C -F      acyl halide                          
+113   0.0       0.0       0.0       0.0        CT-CT-C -Cl     acyl halide                          
+113   0.0       0.0       0.0       0.0        CT-CT-C -Br     acyl halide                          
+114  -0.277     1.228    -0.694     0.0        CT-CT-C -O      aldehyde & ketone & acyl halide      
+115   0.000     0.000    -0.076     0.0        HC-CT-CT-C(O)   aldehyde & ketone & acyl halide      
+116  -1.697    -0.456     0.585     0.0        CT-CT-CT-C      aldehyde & ketone & acyl halide      
+116  -1.697    -0.456     0.585     0.0        CA-CT-CT-C      aldehyde & ketone & acyl halide      
+116  -1.697    -0.456     0.585     0.0        C*-CT-CT-C                                           
+117   0.0       0.0       0.0       0.0        CT-CT-C -HC     aldehyde                             
+118   1.454    -0.144    -0.775     0.0        CT-CT-C -CT     ketone                               
+119   3.000     5.500     0.00      0.0        C -C -OH-HO     oxalic acid, etc.                    
+120   2.25      0.0       0.00      0.0        CA-CT-P -OS     phosphonates                         
+121   3.5      -3.3       1.50      0.0        CT-P -OS-CT     phosphonates                         
+122   0.0       0.0       0.30      0.0        P -OS-CT-HC     phosphonates                         
+123   0.0       0.0       0.00      0.0        O2-P -OS-CT     phosphonates                         
+123   0.0       0.0       0.00      0.0        O -P -OS-CA     phosphonates                         
+123   0.0       0.0       0.00      0.0        O -P -OH-HO     phosphonates                         
+123   0.0       0.0       0.00      0.0        OH-P -OH-HO     phosphonates                         
+124   0.0       0.0       0.00      0.0        CA-CA-CT-P      phosphonates                         
+125   0.0       0.0       0.00      0.0        CA-CT-P -O2     phosphonates                         
+126   0.0       0.0       0.25      0.0        HC-CT-P -O2     phosphonates                         
+126   0.0       0.0       0.25      0.0        HC-CT-P -OS     phosphonates                         
+127   0.0       0.0       0.562     0.0        O2-P -OS-C?     MeOPO3 (2-) mll                      
+128   0.90     -2.93      2.64      0.0        O2-P -OS-CT     dimethyl phosphate                   
+129   0.0       2.990     0.00      0.0        CA-CA-OS-P      PhOPO3 (2-) mll                      
+130   2.0       0.0       0.0       0.0        NT-CT-CT-Cl     2-chloroethylamines                  
+131   0.0       0.0       0.400     0.0        HC-CT-CT-Cl     alkyl chloride                       
+132   0.0       0.0       0.400     0.0        CT-CT-CT-Cl     alkyl chloride                       
+133  -0.25      0.0       0.000     0.0        Cl-CT-CT-Cl     dichloride                           
+131   0.0       0.0       0.400     0.0        HC-CT-CT-I      alkyl iodide                         
+132   0.0       0.0       0.400     0.0        CT-CT-CT-I      alkyl iodide                         
+133   0.000     0.150     0.000     0.0        CT-CT-CA-CA     ethyl benzene                        
+134   4.478    -2.1746    0.000     0.0        HO-OH-CT-CT     trifluoroethanol                     
+135   0.000     0.000     0.476     0.0        HC-CT-OH-HO     trifluoroethanol                     
+136   0.000     0.000     0.3137    0.0        F-CT-CT-HC      trifluoroethanol                     
+137   0.000     0.000     0.5401    0.0        F -CT-CT-OH     trifluoroethanol                     
+138   3.200     4.900     0.000     0.0        CT-C -OH-HO     1,2-diacid monoanion                 
+139  -1.000    -1.900    -0.900     0.0        CT-CT-C -O      1,2-diacid monoanion                 
+140   0.800     0.000     0.900     0.0        C -CT-CT-C      1,2-diacid monoanion                 
+141   1.671    -4.901     0.669     0.0        H -N -SY-CA     sulfonamide                          
+142   1.362    -1.457     0.149     0.0        HC-CT-N -SY     sulfonamide                          
+143   2.074    -2.966     2.473     0.0        CT-N -SY-CA     sulfonamide                          
+144   2.929    -2.533     0.497     0.0        CT-CT-N -SY     sulfonamide                          
+145   1.656    -0.768    -0.117     0.0        CA-CA-SY-N      sulfonamide                          
+146   0.0       0.0       0.0       0.0        ??-??-SY-OY     sulfonamide                          
+146   0.0       0.0       0.0       0.0        ??-CA-SY-OY     sulfonamide                          
+146   0.0       0.0       0.0       0.0        ??-N -SY-OY     sulfonamide                          
+146   0.0       0.0       0.0       0.0        ??-CT-SY-OY     sulfonamide                          
+146   0.0       0.0       0.0       0.0        ??-CT-SY-N      sulfonamide                          
+147   0.0       0.0       0.400     0.0        HC-CT-CT-F      alkyl fluoride                       
+148   0.300    -0.4       0.400     0.0        CT-CT-CT-F      alkyl fluoride                       
+149  -2.5       0.0       0.250     0.0        F -CT-CT-F      1,2-difluoride                       
+149  -2.5       0.0       0.250     0.0        F -CF-CF-F      perfluoroalkane JPC 105, 4118 (2001) 
+150  -1.336     0.0       0.0       0.0        CT-CT-CT-O?     hexopyranoses                        
+151   2.674    -2.883     1.026     0.0        CT-CT-OH-HO     hexopyranoses                        
+152   9.066     0.0       0.0       0.0        OH-CT-CT-OH     hexopyranoses                        
+153  -0.375    -1.358     0.004     0.0        CT-OS-CO-OH     hexopyranoses                        
+153  -0.375    -1.358     0.004     0.0        CT-OS-CO-OS     hexopyranoses                        
+154  -1.257    -1.806     0.003     0.0        OS-CO-OH-HO     hexopyranoses                        
+155   4.319     0.0       0.0       0.0        OH-CT-CT-OS     hexopyranoses                        
+156   6.622     0.948    -1.388    -2.118      CF-CF-CF-CF     perfluoroalkane JPC 105, 4118 (2001) 
+157   0.0       0.0       0.400     0.0        HC-CT-CT-Br     alkyl bromide                        
+158   0.0       0.0       0.400     0.0        CT-CT-CT-Br     alkyl bromide                        
+159   0.0       0.0       0.400     0.0        CA-CA-CT-Br     alkyl bromide                        
+160   0.0      21.0       0.0       0.0        O -C -X -Y      improper torsion                     
+161   0.0       5.0       0.0       0.0        Z -N -X -Y      improper torsion 9/08 was 2.0        
+162   0.0       5.0       0.0       0.0        Z -CA-X -Y      improper torsion 9/08 was 2.2        
+163   0.300     0.0       0.400     0.0        CF-CF-CF-F      perfluoroalkane JPC 105, 4118 (2001) 
+164  -1.0       0.0       0.250     0.0        F -CT-CT-Cl     1,2-chlorofluoro ethane              
+165   0.0       7.250     0.0       0.0        ??-CA-CA-??     in aromatic ring                     
+165   0.0       7.250     0.0       0.0        CA-CA-CA-CA                                          
+165   0.0       7.250     0.0       0.0        CA-CA-CA-CY                                          
+165   0.0       7.250     0.0       0.0        CA-CA-CA-CM                                          
+165   0.0       7.250     0.0       0.0        CA-CA-CA-HA                                          
+165   0.0       7.250     0.0       0.0        CY-CA-CA-HA                                          
+165   0.0       7.250     0.0       0.0        CM-CA-CA-HA                                          
+165   0.0       7.250     0.0       0.0        C#-CA-CA-HA                                          
+165   0.0       7.250     0.0       0.0        C=-CA-CA-HA                                          
+165   0.0       7.250     0.0       0.0        C=-CA-CA-CA                                          
+165   0.0       7.250     0.0       0.0        C=-CA-CA-CT                                          
+165   0.0       7.250     0.0       0.0        HA-CA-CA-HA                                          
+165   0.0       7.250     0.0       0.0        CA-CA-C!-CA                                          
+165   0.0       7.250     0.0       0.0        CA-CA-C!-C!                                          
+165   0.0       7.250     0.0       0.0        CA-CA-CA-C!                                          
+165   0.0       7.250     0.0       0.0        C!-CA-CA-HA                                          
+165   0.0       7.250     0.0       0.0        HA-CA-C!-C!                                          
+165   0.0       7.250     0.0       0.0        HA-CA-C!-CA                                          
+165   0.0       7.250     0.0       0.0        CA-CA-C!-NC                                          
+165   0.0       7.250     0.0       0.0        CA-C!-NC-CA                                          
+165   0.0       7.250     0.0       0.0        C!-C!-CA-NC                                          
+165   0.0       7.250     0.0       0.0        CA-C!-CA-NC                                          
+165   0.0       7.250     0.0       0.0        C!-CA-CA-NC                                          
+165   0.0       7.250     0.0       0.0        C!-C!-NC-CA                                          
+165   0.0       7.250     0.0       0.0        C!-C!-N -C                                           
+165   0.0       7.250     0.0       0.0        C!-C!-CM-C                                           
+165   0.0       7.250     0.0       0.0        NC-C!-CA-HA                                          
+165   0.0       7.250     0.0       0.0        CA-CA-CA-F                                           
+165   0.0       7.250     0.0       0.0        CA-CA-CA-Cl                                          
+165   0.0       7.250     0.0       0.0        CA-CA-CA-Br                                          
+165   0.0       7.250     0.0       0.0        CA-CA-CA-I                                           
+165   0.0       7.250     0.0       0.0        HA-CA-CA-F                                           
+165   0.0       7.250     0.0       0.0        HA-CA-CA-Cl                                          
+165   0.0       7.250     0.0       0.0        HA-CA-CA-Br                                          
+165   0.0       7.250     0.0       0.0        HA-CA-CA-I                                           
+165   0.0       7.250     0.0       0.0        CA-CA-CA-N?                                          
+165   0.0       7.250     0.0       0.0        HA-CA-CA-NT                                          
+165   0.0       7.250     0.0       0.0        HA-C=-C=-C?                                          
+165   0.0       7.250     0.0       0.0        C -C=-C=-C                                           
+165   0.0       7.250     0.0       0.0        HA-CA-CA-CT                                          
+165   0.0       7.250     0.0       0.0        CT-CA-CA-CT                                          
+165   0.0       7.250     0.0       0.0        CT-CA-CA-CA                                          
+165   0.0       7.250     0.0       0.0        C#-CA-CA-CA                                          
+165   0.0       7.250     0.0       0.0        CA-CA-CA-CB                                          
+165   0.0       7.250     0.0       0.0        HA-CA-CA-CB                                          
+165   0.0       7.250     0.0       0.0        HA-CA-CB-CB                                          
+165   0.0       7.250     0.0       0.0        HA-CA-CB-CA                                          
+165   0.0       7.250     0.0       0.0        CA-CA-CA-O?                                          
+165   0.0       7.250     0.0       0.0        HA-CA-CA-O?                                          
+165   0.0       7.250     0.0       0.0        CT-CA-CA-O?                                          
+165   0.0       7.250     0.0       0.0        O?-CA-CA-O?                                          
+165   0.0       7.250     0.0       0.0        CA-CA-CA-S?                                          
+165   0.0       7.250     0.0       0.0        HA-CA-CA-S?                                          
+165   0.0       7.250     0.0       0.0        CT-CA-CA-S?                                          
+165   0.0       7.250     0.0       0.0        S?-CA-CA-S?                                          
+165   0.0       7.250     0.0       0.0        HA-CM-C!-N?                                          
+165   0.0       7.250     0.0       0.0        HA-CM-C!-N                                           
+165   0.0       7.250     0.0       0.0        HA-CA-CA-N?                                          
+165   0.0       7.250     0.0       0.0        CT-CA-CA-N?                                          
+165   0.0       7.250     0.0       0.0        O?-CA-CA-N?                                          
+165   0.0       7.250     0.0       0.0        N?-CA-CA-N?                                          
+165   0.0       7.250     0.0       0.0        ??-CB-CB-??                                          
+165   0.0       7.250     0.0       0.0        CA-CB-CB-CA                                          
+165   0.0       7.250     0.0       0.0        CB-CB-CB-CB                                          
+165   0.0       7.250     0.0       0.0        CB-CB-CB-CA                                          
+165   0.0       7.250     0.0       0.0        CA-CA-CB-CB                                          
+165   0.0       7.250     0.0       0.0        CB-CA-CB-CB                                          
+165   0.0       7.250     0.0       0.0        CA-CA-CB-CA                                          
+165   0.0       7.250     0.0       0.0        CA-CB-CA-CB                                          
+165   0.0       7.250     0.0       0.0        C?-CB-CB-C?                                          
+165   0.0       7.250     0.0       0.0        N?-CB-CB-C?                                          
+165   0.0       7.250     0.0       0.0        N?-CB-CB-N?                                          
+165   0.0       7.250     0.0       0.0        ??-CB-CS-??                                          
+165   0.0       7.250     0.0       0.0        ??-CS-C -??                                          
+165   0.0       7.250     0.0       0.0        ??-CR-CS-??                                          
+165   0.0       7.250     0.0       0.0        ??-CS-CW-??                                          
+165   0.0       7.250     0.0       0.0        C?-CS-CW-C?                                          
+165   0.0       7.250     0.0       0.0        C?-CS-CW-H?                                          
+165   0.0       7.250     0.0       0.0        C?-CS-CW-N?                                          
+165   0.0       7.250     0.0       0.0        HA-CS-CW-N?                                          
+165   0.0       7.250     0.0       0.0        HA-CS-CW-C?                                          
+165   0.0       7.250     0.0       0.0        HA-CS-CW-HA                                          
+165   0.0       7.250     0.0       0.0        HA-CS-CP-HA                                          
+165   0.0       7.250     0.0       0.0        HA-CW-CS-CS                                          
+165   0.0       7.250     0.0       0.0        HA-CP-CS-CS                                          
+165   0.0       7.250     0.0       0.0        OS-CP-CS-CS                                          
+165   0.0       7.250     0.0       0.0        HA-CS-CS-CW                                          
+165   0.0       7.250     0.0       0.0        HA-CS-CS-CP                                          
+165   0.0       7.250     0.0       0.0        OA-CW-CS-HA                                          
+165   0.0       7.250     0.0       0.0        HA-CS-CS-HA                                          
+165   0.0       7.250     0.0       0.0        HA-CA-CU-HA                                          
+165   0.0       7.250     0.0       0.0        HA-CW-OA-CW                                          
+165   0.0       7.250     0.0       0.0        NT-CW-OA-CW       JT-R 2014/04 added for 2NH2Furan   
+165   0.0       7.250     0.0       0.0        ??-NC-CA-??                                          
+165   0.0       7.250     0.0       0.0        CS-CW-OA-CW                                          
+165   0.0       7.250     0.0       0.0        OH-CW-CS-CS       JT-R 2014/04 added for 2-hydroxypyr
+165   0.0       7.250     0.0       0.0        OH-CW-CS-HA       JT-R 2014/04 added for 2-hydroxypyr
+165   0.0       7.250     0.0       0.0        OH-CW-NA-CW       JT-R 2014/04 added for 2-hydroxypyr
+165   0.0       7.250     0.0       0.0        SH-CW-NA-CW       JT-R 2014/04 added for 2-thiolpyrro
+165   0.0       7.250     0.0       0.0        SH-CW-CS-HA       JT-R 2014/04 added for 2-thiolpyrro
+165   0.0       7.250     0.0       0.0        SH-CW-CS-CS       JT-R 2014/04 added for 2-thiolpyrro
+165   0.0       7.250     0.0       0.0        S -CW-NA-CW       JT-R 2014/04 added for 2-thiolpyrro
+165   0.0       7.250     0.0       0.0        S -CW-CS-HA       JT-R 2014/04 added for 2-thiolpyrro
+165   0.0       7.250     0.0       0.0        S -CW-CS-CS       JT-R 2014/04 added for 2-thiolpyrro
+165   0.0       7.250     0.0       0.0        NT-CW-NA-CW       JT-R 2014/04 added for 2-aminopyrro
+165   0.0       7.250     0.0       0.0        NT-CW-NA-H        JT-R 2014/04 added for 2-aminopyrro
+165   0.0       7.250     0.0       0.0        CW-CS-CS-CW       JT-R 2014/04 added for Furans      
+165   0.0       7.250     0.0       0.0        OA-CW-CS-CS       JT-R 2014/04 added for Furans      
+165   0.0       7.250     0.0       0.0        CT-CW-OA-CW       JT-R 2014/04 added for Furans      
+165   0.0       7.250     0.0       0.0        CY-CW-OA-CW       JT-R 2014/04 added for Furans      
+165   0.0       7.250     0.0       0.0        CT-CP-SA-CP       JT-R 2014/04 added for Thiophenes  
+165   0.0       7.250     0.0       0.0        OS-CP-SA-CP       JT-R 2014/04 added for Thiophenes  
+165   0.0       7.250     0.0       0.0        S -CP-SA-CP       JT-R 2014/04 added for Thiophenes  
+165   0.0       7.250     0.0       0.0        HA-CP-SA-CP       JT-R 2014/04 added for Thiophenes  
+165   0.0       7.250     0.0       0.0        CS-CP-SA-CP       JT-R 2014/04 added for Thiophenes  
+165   0.0       7.250     0.0       0.0        SA-CP-CS-CS       JT-R 2014/04 added for Thiophenes  
+165   0.0       7.250     0.0       0.0        CP-CS-CS-CP       JT-R 2014/04 added for Thiophenes  
+165   0.0       7.250     0.0       0.0        CT-CP-CS-CS       JT-R 2014/04 added for Thiophenes  
+165   0.0       7.250     0.0       0.0        CW-CS-CB-CB                                          
+165   0.0       7.250     0.0       0.0        CW-OA-CW-OS       JT-R 2014/04 added for 2MeOFuran   
+165   0.0       7.250     0.0       0.0        CW-OA-CW-S        JT-R 2014/04 added for 2MeOFuran   
+165   0.0       7.250     0.0       0.0        OH-CW-CS-HA                                          
+165   0.0       7.250     0.0       0.0        OH-CW-NA-CW                                          
+165   0.0       7.250     0.0       0.0        SH-CW-NA-CW                                          
+165   0.0       7.250     0.0       0.0        SH-CW-CS-HA                                          
+165   0.0       7.250     0.0       0.0        SH-CW-CS-CS                                          
+165   0.0       7.250     0.0       0.0        S -CW-NA-CW                                          
+165   0.0       7.250     0.0       0.0        S -CW-CS-HA                                          
+165   0.0       7.250     0.0       0.0        S -CW-CS-CS                                          
+165   0.0       7.250     0.0       0.0        NT-CW-NA-CW                                          
+165   0.0       7.250     0.0       0.0        NT-CW-NA-H                                           
+165   0.0       7.250     0.0       0.0        CW-CS-CS-CW                                          
+165   0.0       7.250     0.0       0.0        OA-CW-CS-CS                                          
+165   0.0       7.250     0.0       0.0        CT-CW-OA-CW                                          
+165   0.0       7.250     0.0       0.0        CY-CW-OA-CW                                          
+165   0.0       7.250     0.0       0.0        CT-CP-SA-CP                                          
+165   0.0       7.250     0.0       0.0        OS-CP-SA-CP                                          
+165   0.0       7.250     0.0       0.0        S -CP-SA-CP                                          
+165   0.0       7.250     0.0       0.0        HA-CP-SA-CP                                          
+165   0.0       7.250     0.0       0.0        CS-CP-SA-CP                                          
+165   0.0       7.250     0.0       0.0        SA-CP-CS-CS                                          
+165   0.0       7.250     0.0       0.0        CP-CS-CS-CP                                          
+165   0.0       7.250     0.0       0.0        CT-CP-CS-CS                                          
+165   0.0       7.250     0.0       0.0        CW-CS-CB-CB                                          
+165   0.0       7.250     0.0       0.0        CW-OA-CW-OS                                          
+165   0.0       7.250     0.0       0.0        CW-OA-CW-S                                           
+165   0.0       7.250     0.0       0.0        CA-NC-CA-CA                                          
+165   0.0       7.250     0.0       0.0        C?-NC-CA-N?                                          
+165   0.0       7.250     0.0       0.0        CA-NC-CA-HA                                          
+165   0.0       7.250     0.0       0.0        C=-N=-C -HC                                          
+165   0.0       7.250     0.0       0.0        C=-N=-C -CT                                          
+165   0.0       7.250     0.0       0.0        N=-C=-CM-HC                                          
+165   0.0       7.250     0.0       0.0        CA-NC-NC-CT                                          
+165   0.0       7.250     0.0       0.0        CA-NC-NC-CA                                          
+165   0.0       7.250     0.0       0.0        CT-NC-NC-CT                                          
+165   0.0       7.250     0.0       0.0        ??-NC-CB-??                                          
+165   0.0       7.250     0.0       0.0        C?-NC-CB-C?                                          
+165   0.0       7.250     0.0       0.0        C?-NC-CB-N?                                          
+165   0.0       7.250     0.0       0.0        ??-NA-CB-??                                          
+165   0.0       7.250     0.0       0.0        ??-NB-CB-??                                          
+165   0.0       7.250     0.0       0.0        ??-NB-CR-??                                          
+165   0.0       7.250     0.0       0.0        ??-NB-CU-??                                          
+165   0.0       7.250     0.0       0.0        C?-NA-CB-C?                                          
+165   0.0       7.250     0.0       0.0        C?-NA-CB-N?                                          
+165   0.0       7.250     0.0       0.0        C?-NB-CB-C?                                          
+165   0.0       7.250     0.0       0.0        N?-CR-SA-CW                                          
+165   0.0       7.250     0.0       0.0        CR-NB-CV-CW                                          
+165   0.0       7.250     0.0       0.0        CR-NB-CV-HA                                          
+165   0.0       7.250     0.0       0.0        CU-CW-SA-CR                                          
+165   0.0       7.250     0.0       0.0        CR-SA-CW-CV                                          
+165   0.0       7.250     0.0       0.0        HA-CW-SA-CR                                          
+165   0.0       7.250     0.0       0.0        CW-SA-CR-NB                                          
+165   0.0       7.250     0.0       0.0        SA-CR-NB-CU                                          
+165   0.0       7.250     0.0       0.0        SA-CR-NB-CV                                          
+165   0.0       7.250     0.0       0.0        CR-NB-CU-CW                                          
+165   0.0       7.250     0.0       0.0        NB-CU-CW-SA                                          
+165   0.0       7.250     0.0       0.0        CU-CW-OA-CR                                          
+165   0.0       7.250     0.0       0.0        CW-OA-CR-NB                                          
+165   0.0       7.250     0.0       0.0        OA-CR-NB-CU                                          
+165   0.0       7.250     0.0       0.0        NB-CU-CW-OA                                          
+165   0.0       7.250     0.0       0.0        NB-CU-CW-HA                                          
+165   0.0       7.250     0.0       0.0        NB-CU-CW-SA                                          
+165   0.0       7.250     0.0       0.0        NB-CV-CW-OA                                          
+165   0.0       7.250     0.0       0.0        NB-CV-CW-HA                                          
+165   0.0       7.250     0.0       0.0        NB-CV-CW-SA                                          
+165   0.0       7.250     0.0       0.0        ??-N -CB-??                                          
+165   0.0       7.250     0.0       0.0        HA-CU-CW-??                                          
+165   0.0       7.250     0.0       0.0        HA-CW-CU-??                                          
+165   0.0       7.250     0.0       0.0        ??-NC-CR-??                                          
+165   0.0       7.250     0.0       0.0        ??-NC-CQ-??                                          
+165   0.0       7.250     0.0       0.0        C?-NC-CQ-HA                                          
+165   0.0       7.250     0.0       0.0        C?-NC-CQ-N?                                          
+165   0.0       7.250     0.0       0.0        ??-N -CQ-??                                          
+165   0.0       7.250     0.0       0.0        C?-N -CQ-N?                                          
+165   0.0       7.250     0.0       0.0        C?-N -CQ-HA                                          
+165   0.0       7.250     0.0       0.0        H -N -CQ-??                                          
+165   0.0       7.250     0.0       0.0        NC-CA-CB-O?                                          
+165   0.0       7.250     0.0       0.0        C!-C!-CB-O?                                          
+165   0.0       7.250     0.0       0.0        NC-C!-CB-CS                                          
+165   0.0       7.250     0.0       0.0        O?-CB-CS-NC                                          
+165   0.0       7.250     0.0       0.0        NC-CS-CS-C?                                          
+165   0.0       7.250     0.0       0.0        LP-NC-CA-CA                                          
+165   0.0       7.250     0.0       0.0        LP-NC-CA-HA                                          
+165   0.0       7.250     0.0       0.0        LP-NC-CB-CA                                          
+165   0.0       7.250     0.0       0.0        LP-NC-NC-CA                                          
+165   0.0       7.250     0.0       0.0        LP-NB-CR-NA                                          
+165   0.0       7.250     0.0       0.0        LP-NB-CV-CW                                          
+165   0.0       7.250     0.0       0.0        LP-NB-CR-??                                          
+165   0.0       7.250     0.0       0.0        LP-NB-CV-??                                          
+165   0.0       7.250     0.0       0.0        LP-NB-NA-CW                                          
+165   0.0       7.250     0.0       0.0        LP-NB-NA-??                                          
+166   0.0       2.80      0.0       0.0        ??-CW-NA-??                                          
+167   0.0       4.65      0.0       0.0        ??-NA-CR-??                                          
+168   0.0      10.0       0.0       0.0        HA-CR-NB-??                                          
+168   0.0      10.0       0.0       0.0        N?-CR-NB-C?                                          
+168   0.0      10.0       0.0       0.0        ??-CR-NB-??                                          
+168   0.0      10.0       0.0       0.0        ??-CW-NB-??                                          
+168   0.0      10.0       0.0       0.0        ??-CR-NA-??                                          
+168   0.0      10.0       0.0       0.0        HA-CR-NA-??                                          
+168   0.0      10.0       0.0       0.0        N?-CR-NA-C?                                          
+168   0.0      10.0       0.0       0.0        ??-CR-NC-??                                          
+168   0.0      10.0       0.0       0.0        ??-CK-NB-??                                          
+168   0.0      10.0       0.0       0.0        ??-CK-NA-??                                          
+168   0.0      10.0       0.0       0.0        ??-CK-NC-??                                          
+168   0.0      10.0       0.0       0.0        ??-NA-NB-??                                          
+168   0.0      10.0       0.0       0.0        ??-NB-NB-??                                          
+169   0.0       4.80      0.0       0.0        ??-NB-CV-??                                          
+170   0.0      10.75      0.0       0.0        ??-CW-CV-??                                          
+170   0.0      10.75      0.0       0.0        C?-CW-CV-C?                                          
+170   0.0      10.75      0.0       0.0        C?-CW-CV-HA                                          
+170   0.0      10.75      0.0       0.0        HA-CW-CV-C?                                          
+170   0.0      10.75      0.0       0.0        HA-CW-CV-HA                                          
+170   0.0      10.75      0.0       0.0        ??-CW-CW-??                                          
+170   0.0      10.75      0.0       0.0        C?-CW-CW-C?                                          
+170   0.0      10.75      0.0       0.0        N?-CW-CW-N?                                          
+170   0.0      10.75      0.0       0.0        C?-CW-CW-HA                                          
+170   0.0      10.75      0.0       0.0        N?-CW-CW-HA                                          
+170   0.0      10.75      0.0       0.0        H?-CW-CW-C?                                          
+170   0.0      10.75      0.0       0.0        H?-CW-CW-HA                                          
+170   0.0      10.75      0.0       0.0        HA-CW-CW-HA                                          
+170   0.0      10.75      0.0       0.0        SA-CW-CW-HA                                          
+170   0.0      10.75      0.0       0.0        SA-CW-CU-HA                                          
+170   0.0      10.75      0.0       0.0        SA-CW-CV-HA                                          
+170   0.0      10.75      0.0       0.0        SA-CP-CS-HA                                          
+170   0.0      10.75      0.0       0.0        SA-CP-CP-HA                                          
+171   0.0       5.00      0.0       0.0        ??-NA-CW-??                                          
+171   0.0       5.00      0.0       0.0        C?-NA-CW-C?                                          
+171   0.0       5.00      0.0       0.0        N?-NA-CW-C?                                          
+171   0.0       5.00      0.0       0.0        C?-NA-CW-H?                                          
+171   0.0       5.00      0.0       0.0        N?-NA-CW-H?                                          
+171   0.0       5.00      0.0       0.0        H -NA-CW-??                                          
+171   0.0       5.00      0.0       0.0        H -NA-CR-??                                          
+171   0.0       5.00      0.0       0.0        H -NA-CB-??                                          
+171   0.0       5.00      0.0       0.0        H -NA-CB-??                                          
+171   0.0       5.00      0.0       0.0        H -NA-CW-C!                                          
+171   0.0       5.00      0.0       0.0        CW-NA-CW-CS                                          
+171   0.0       5.00      0.0       0.0        H -NA-CW-CS                                          
+171   0.0       5.00      0.0       0.0        CW-NA-CW-C!                                          
+171   0.0       5.00      0.0       0.0        HA-CW-NA-CW                                          
+171   0.0       5.00      0.0       0.0        H -NA-CW-HA                                          
+171   0.0       5.00      0.0       0.0        CT-NS-CW-C!                                          
+171   0.0       5.00      0.0       0.0        CS-CW-NS-CW                                          
+171   0.0       5.00      0.0       0.0        CT-NS-CW-CS                                          
+171   0.0       5.00      0.0       0.0        HA-CW-NS-CW                                          
+171   0.0       5.00      0.0       0.0        HA-CW-NS-CT                                          
+172   0.0      13.05      0.0       0.0        ??-C*-CW-??                                          
+173   0.0       3.35      0.0       0.0        ??-C*-CB-??                                          
+174   0.0       7.00      0.0       0.0        ??-CA-CB-??                                          
+174   0.0       7.00      0.0       0.0        C?-CA-CB-C?                                          
+174   0.0       7.00      0.0       0.0        N?-CA-CB-N?                                          
+174   0.0       7.00      0.0       0.0        C?-CA-CB-N?                                          
+174   0.0       7.00      0.0       0.0        N?-CA-CB-C?                                          
+174   0.0       7.00      0.0       0.0        ??-C -CB-??                                          
+174   0.0       7.00      0.0       0.0        O -C -CB-C?                                          
+174   0.0       7.00      0.0       0.0        N?-C -CB-N?                                          
+174   0.0       7.00      0.0       0.0        O -C -CB-N?                                          
+174   0.0       7.00      0.0       0.0        N?-C -CB-C?                                          
+175   0.0       6.0       0.0       0.0        ??-CB-CN-??                                          
+176   0.0       3.05      0.0       0.0        ??-NA-CN-??                                          
+177   0.0       3.0       0.0       0.0        ??-CW-NA-??                                          
+177   0.0       3.0       0.0       0.0        CW-CW-N -C                                           
+178  -1.42     -0.62      0.1       0.0        CT-CT-OS-P in methyl ethyl phosphate                 
+179   0.000     3.80      0.0       0.0        NC-CA-NT-H      2-amino pyridine, JT-R 2014/04 fit AA
+179   0.000     3.80      0.0       0.0        N?-CA-NT-H      aniline-like                         
+179   0.000     3.80      0.0       0.0        N?-CA-N2-H      aniline-like                         
+180   0.000     0.000     0.1320    0.0        HC-CT-C -OS     esters                               
+181   4.669     5.124     0.0000    0.0        CT-C -OS-CT     esters                               
+181   4.669     5.124     0.0000    0.0        OS-C -OS-CT     carbonates - tentative               
+181   4.669     5.124     0.0000    0.0        HC-C -OS-CT     esters                               
+182   0.000     5.124     0.0000    0.0        O -C -OS-CT     esters                               
+183   0.000     0.000     0.1980    0.0        C -OS-CT-HC     esters                               
+184   0.000     0.000    -0.5530    0.0        CT-CT-C -OS     esters                               
+185  -1.220    -0.126     0.4220    0.0        CT-CT-OS-C      esters                               
+186   1.000     0.0       0.0       0.0        CA-CT-CT-N3     phenethylammonium - JACS 119,12292(97
+187  -0.800     0.0       0.0       0.0        CA-CT-CT-NT     phenethylamines - fit    "           
+188   0.0       0.40      0.0       0.0        CT-CT-NO-ON     nitroethane                          
+189   0.0       1.15      0.0       0.0        CA-CA-NO-ON     nitrobenzene                         
+190   0.000     1.620     0.000    -0.44       N2-CA-CA-CA     benzamidine; fit to 6-31G* 8/02      
+191   0.000     3.651     0.000     0.0        CT-NY-CA-NC     neutral arg                          
+192   0.000     4.000     0.000     0.0        CT-CT-NT-H      azetidine - 4 membered cyclic amines 
+193   0.200    -0.417     0.418     0.0        CT-CT-NT-H      pyrrolidine 5 membered cyclic amines 
+199   0.416    -0.128     0.695     0.0        CT-NT-CT-CT     amine (repeated here so taken first b
+194   1.536    -0.128     0.695     0.0        CT-NT-CT-CT     exocyclic amines                     
+195   1.464    -0.128     0.695     0.0        CT-NT-CT-CT     exocyclic 1,4-diamines               
+196   0.819    -0.417     0.418     0.0        CT-CT-NT-H      cyclic amines                        
+197   1.522    -0.417     0.418     0.0        CT-CT-NT-H      cyclic 1,4-diamines                  
+198  11.035    -0.968     0.270     0.0        NT-CT-CT-NT     amine all-atom                       
+199   0.416    -0.128     0.695     0.0        CT-NT-CT-CT     amine all-atom                       
+200   0.0       0.0       0.56      0.0        HC-CT-NT-CT     amine all-atom                       
+200   0.0       0.0       0.56      0.0        HC-CT-NT-CA     amine all-atom                       
+201   1.244     0.000     0.167     0.0        CT-CT-CW-NA     2-alkyl pyrrole - JT-R 2014/04 AA/CM1
+202   0.900     0.230    -0.505     0.0        CT-C=-C=-CM     2-Me-1,3-butadiene                   
+202   0.900     0.230    -0.505     0.0        CT-C=-C -O?     2-Me-1,3-butadiene-like              
+202   0.900     0.230    -0.505     0.0        CT-CM-C -O?     2-Me-1,3-butadiene-like              
+203   0.8      -3.0       0.0       0.0        CT-C -C=-CM     methyl vinyl ketone                  
+204   3.2      -3.0       0.0       0.0        CM-C=-C -OH     acrylic acid                         
+204   3.2      -3.0       0.0       0.0        CM-CM-C -OH     acrylic acid-like                    
+204   3.2      -3.0       0.0       0.0        C#-C#-C -OH     acrylic acid-like                    
+205   2.5       6.0       0.0       0.0        CM-C=-C -O      acrolein                             
+205   2.5       6.0       0.0       0.0        CM-CM-C -O      acrolein-like                        
+205   2.5       6.0       0.0       0.0        C#-C#-C -O      acrolein-like                        
+206   0.0       0.2       0.0       0.0        CA-CA-C -CT     aryl ketone                          
+206   0.0       0.2       0.0       0.0        CA-CA-C -HC     aryl aldehyde                        
+207   0.0       2.100     0.0       0.0        CA-CA-N -??     N-phenylamide                        
+207   0.0       2.100     0.0       0.0        CA-CA-N -H      N-phenylamide                        
+207   0.0       2.100     0.0       0.0        CA-CA-N -C      N-phenylamide                        
+207   0.0       2.100     0.0       0.0        CA-CA-N -CT     N-phenylamide                        
+207   0.0       2.100     0.0       0.0        CA-CA-N -CR     diarylamine                          
+207   0.0       2.100     0.0       0.0        CA-CA-N -CW     diarylamine                          
+207   0.0       2.100     0.0       0.0        CA-CA-NT-CR     diarylamine                          
+207   0.0       2.100     0.0       0.0        CA-CA-NT-CW     diarylamine                          
+207   0.0       2.100     0.0       0.0        SA-CR-N -CA     diarylamine                          
+207   0.0       2.100     0.0       0.0        SA-CR-NT-CA     diarylamine                          
+207   0.0       2.100     0.0       0.0        NB-CR-N -CA     diarylamine                          
+207   0.0       2.100     0.0       0.0        NB-CR-NT-CA     diarylamine                          
+207   0.0       2.100     0.0       0.0        NB-CR-N3-CA     diarylamine                          
+207   0.0       2.100     0.0       0.0        SA-CR-N -H      diarylamine                          
+207   0.0       2.100     0.0       0.0        SA-CR-NT-H      diarylamine                          
+207   0.0       2.100     0.0       0.0        NB-CR-N -H      diarylamine                          
+207   0.0       2.100     0.0       0.0        NB-CR-N -CT     diarylamine                          
+207   0.0       2.100     0.0       0.0        NB-CR-N3-CT     diarylamine                          
+207   0.0       2.100     0.0       0.0        NB-CR-NT-H      diarylamine                          
+207   0.0       2.100     0.0       0.0        OA-CR-N -CA     diarylamine                          
+207   0.0       2.100     0.0       0.0        OA-CR-N -H      diarylamine                          
+207   0.0       2.100     0.0       0.0        OA-CW-N -CA     diarylamine                          
+207   0.0       2.100     0.0       0.0        OA-CW-N -H      diarylamine                          
+207   0.0       2.100     0.0       0.0        SA-CW-N -CA     diarylamine                          
+207   0.0       2.100     0.0       0.0        SA-CW-N -H      diarylamine                          
+207   0.0       2.100     0.0       0.0        CA-CA-N -CQ     diarylamine                          
+207   0.0       2.100     0.0       0.0        CA-CA-NT-CQ     diarylamine                          
+208   0.0       2.100     0.0       0.0        CA-CA-C -O      aryl carbonyl                        
+208   0.0       2.100     0.0       0.0        CA-CA-C -OS     aryl acid, ester                     
+208   0.0       2.100     0.0       0.0        CA-CA-C -OH     aryl acid, ester                     
+208   0.0       2.100     0.0       0.0        CS-CS-C -O      aryl carbonyl 6/8/06                 
+208   0.0       2.100     0.0       0.0        CW-CS-C -O      aryl carbonyl 6/8/06                 
+208   0.0       2.100     0.0       0.0        CS-CS-C -S=     aryl carbonyl 6/8/06                 
+208   0.0       2.100     0.0       0.0        CW-CS-C -S=     aryl carbonyl 6/8/06                 
+209   0.0       2.500     0.0       0.0        CA-CA-OS-C      phenyl acetate                       
+210   0.000     5.000     0.00      0.0        O -C -OH-HO     benzoic acids                        
+210   0.000     5.000     0.00      0.0        O -C -OS-CT     benzoic esters                       
+211   4.000     5.000     0.00      0.0        CA-C -OH-HO     benzoic acids                        
+211   4.000     5.000     0.00      0.0        CA-C -OS-CT     benzoic esters                       
+212   0.000     5.000     0.000     0.0        O -C -OS-CA     phenyl acetate                       
+213   1.500     5.000     0.000     0.0        CT-C -OS-CA     phenyl acetate                       
+214   0.000     1.100     0.0       0.0        CA-CA-C -N      aryl amides                          
+214   0.000     1.100     0.0       0.0        CS-CS-C -N      aryl amides 6/8/06                   
+214   0.000     1.100     0.0       0.0        CW-CS-C -N      aryl amides 6/8/06                   
+215   0.0       2.133     0.0       0.0        CA-CA-NT-H      aniline JT-R 2014/04 fit AA to MP2/au
+215   0.0       2.133     0.0       0.0        CA-CA-N2-H      aniline JT-R 2014/04 fit AA to MP2/au
+215   0.0       2.133     0.0       0.0        CS-CW-NT-H      aniline-like 2014/04 JT-R copy for 2-
+215   0.0       2.133     0.0       0.0        ??-CA-N2-H      aniline-like                         
+215   0.0       2.133     0.0       0.0        ??-CQ-N2-H      aniline-like                         
+215   0.0       2.133     0.0       0.0        CB-CA-N2-H      aniline-like                         
+215   0.0       2.133     0.0       0.0        SA-CR-N -H      aniline-like                         
+215   0.0       2.133     0.0       0.0        OA-CR-N -H      aniline-like                         
+216   0.0       3.880     0.0       0.15       CA-CA-NT-CT     substituted-aniline JT-R 2014/04 AA/C
+216   0.0       3.880     0.0       0.15       CS-CW-NT-CT     substituted-aniline JT-R 2014/04 copy
+217   2.817    -0.169     0.543     0.0        CT-CM-CT-CT     alkenes                              
+218   0.346     0.405    -0.904     0.0        CM-CM-CT-CT     alkenes                              
+218   0.346     0.405    -0.904     0.0        C#-C#-CT-CT     alkenes                              
+218   0.346     0.405    -0.904     0.0        C=-CM-CT-CT     alkenes                              
+218   0.346     0.405    -0.904     0.0        C=-C=-CT-CT     alkenes - guess                      
+219   0.0       3.431     0.0       0.0        CM-CM-CA-CA     styrene JT-R 2014/04 fit to MP2/aug-c
+219   0.0       3.431     0.0       0.0        CM-C=-CA-CA     styrene JT-R 2014/04 to MP2/aug-ccpVT
+219   0.0       3.431     0.0       0.0        CM-CM-CW-CS     vinyl pyrrole JT-R 2014/04           
+219   1.241     3.353    -0.286     0.0        C#-C#-CA-CA     stilbene                             
+220   0.205    -0.531     0.000     0.0        CT-CM-CA-CA     1-methylstyrene                      
+220   0.205    -0.531     0.000     0.0        CT-C#-CA-CA     1-methylstyrene                      
+221   0.0      30.0       0.0       0.0        Z -CM-X -Y      improper torsion                     
+222   0.0      14.0       0.0       0.0        ??-CM-CM-??     alkene                               
+222   0.0      14.0       0.0       0.0        ??-C#-C#-??     alkene                               
+222   0.0      14.0       0.0       0.0        CT-CM-CM-CT     alkene                               
+222   0.0      14.0       0.0       0.0        CT-CM-C=-CT     alkene                               
+222   0.0      14.0       0.0       0.0        CT-CM-C=-HC     alkene                               
+222   0.0      14.0       0.0       0.0        HC-CM-C=-HC     alkene                               
+222   0.0      14.0       0.0       0.0        HC-CM-C=-CT     alkene                               
+222   0.0      14.0       0.0       0.0        CT-CM-CM-HC     alkene                               
+222   0.0      14.0       0.0       0.0        CA-CM-CM-HC     alkene                               
+222   0.0      14.0       0.0       0.0        CA-C=-CM-HC     alkene                               
+222   0.0      14.0       0.0       0.0        CA-C=-CM-CT     alkene                               
+222   0.0      14.0       0.0       0.0        C -CM-CM-HC     alkene                               
+222   0.0      14.0       0.0       0.0        HC-CM-CM-HC     alkene                               
+222   0.0      14.0       0.0       0.0        HC-CM-C=-C=     alkene                               
+222   0.0      14.0       0.0       0.0        CT-CM-C=-C=     alkene                               
+222   0.0      14.0       0.0       0.0        HC-C#-C#-HC     triene                               
+222   0.0      14.0       0.0       0.0        HC-C#-C#-CT     triene                               
+222   0.0      14.0       0.0       0.0        CT-C#-C#-CT     triene                               
+222   0.0      14.0       0.0       0.0        C=-C#-C#-C=     triene                               
+222   0.0      14.0       0.0       0.0        C#-C#-C#-C=     triene                               
+222   0.0      14.0       0.0       0.0        C#-C#-C#-CA     triene                               
+222   0.0      14.0       0.0       0.0        C#-C#-C#-CT     triene                               
+222   0.0      14.0       0.0       0.0        C#-C#-C#-HC     triene                               
+222   0.0      14.0       0.0       0.0        HC-C#-C#-C=     triene                               
+222   0.0      14.0       0.0       0.0        CT-C#-C#-C=     triene                               
+222   0.0      14.0       0.0       0.0        CA-C#-C#-HC     triene                               
+222   0.0      14.0       0.0       0.0        CA-C#-C#-CT     triene                               
+222   0.0      14.0       0.0       0.0        CA-C#-C#-C=     triene                               
+222   0.0      14.0       0.0       0.0        CA-C#-C#-CA     triene                               
+222   0.0      14.0       0.0       0.0        C#-C=-CM-HC     triene                               
+222   0.0      14.0       0.0       0.0        C#-C=-CM-CT     triene                               
+222   0.0      14.0       0.0       0.0        CZ-CM-CM-HC     enyne                                
+222   0.0      14.0       0.0       0.0        CZ-CM-CM-CT     enyne                                
+222   0.0      14.0       0.0       0.0        CZ-CM-CM-C?     enyne                                
+222   0.0      14.0       0.0       0.0        Cl-CM-CM-HC     chloroalkene                         
+222   0.0      14.0       0.0       0.0        HC-CM-CM-OS     vinyl ether                          
+222   0.0      14.0       0.0       0.0        CT-CM-CM-OS     vinyl ether                          
+222   0.0      14.0       0.0       0.0        SY-CM-CM-HC     vinyl sulfone                        
+222   0.0      14.0       0.0       0.0        SY-CM-CM-CT     vinyl sulfone                        
+222   0.0      14.0       0.0       0.0        HC-CM-CM-OH     vinyl alcohol                        
+222   0.0      14.0       0.0       0.0        CT-CM-CM-OH     vinyl alcohol                        
+222   0.0      14.0       0.0       0.0        C -CM-CM-N      conj. amide                          
+222   0.0      14.0       0.0       0.0        C -C=-CM-N      conj. amide                          
+222   0.0      14.0       0.0       0.0        CT-C -NC-CT     imine                                
+222   0.0      14.0       0.0       0.0        HC-C -NC-H      imine                                
+222   0.0      14.0       0.0       0.0        N -C -NC-H      quanidine                            
+222   0.0      14.0       0.0       0.0        N -C -NC-CT     quanidine                            
+222   0.0      14.0       0.0       0.0        N -C -NC-CA     quanidine                            
+222   0.0      14.0       0.0       0.0        N -C -NC-CZ     quanidine                            
+222   0.0      14.0       0.0       0.0        CT-C -NC-O?     oxime                                
+222   0.0      14.0       0.0       0.0        HC-C -NC-O?     oxime                                
+223   0.0       2.17      0.0       0.0        CA-C!-C -CA     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-NA-NB     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-NA-CW     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CW-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CW-NA     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CS-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CM-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CU-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CU-NB     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CV-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CV-NB     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CR-OA     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CW-SA     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CR-SA     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-N -C      biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-N -CM     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        NC-C!-N -C      biphenyl-like                        
+223   0.0       2.17      0.0       0.0        NC-C!-N -CM     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CS-CS-CS-N?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        OS-CS-CS-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        OS-CS-CS-N?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        NA-CS-CS-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        NA-CS-CS-N?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CW-CV-CS-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CW-CV-CS-N?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        NB-CV-CS-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        NB-CV-CS-N?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        N?-CR-CS-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        N?-CR-CW-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        ??-N -CU-??     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        ??-N -CW-??     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        ??-N -CS-??     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        ??-CM-CU-??     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        ??-CM-CW-??     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        ??-CM-CS-??     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        NC-C!-CU-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        NC-C!-CU-N?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CU-C?     biphenyl-like                        
+223   0.0       2.17      0.0       0.0        CA-C!-CU-N?     biphenyl-like                        
+224  -1.6      14.0       0.0       0.0        Cl-CM-CM-Cl     chloroalkene                         
+225   0.000     0.000     0.300     0.0        HC-CT-P+-CT      phosphonium ion                     
+226   0.000     0.000     0.300     0.0        HC-CT-CT-P+       "                                  
+227   1.000    -0.500     0.500     0.0        CT-CT-P+-CT       "                                  
+228   3.132    -1.491     2.744     0.0        CK-N*-CT-OS     Ping added,nucleoside                
+229   2.756    -0.872    -3.680     0.0        CK-NA-CT-CT     Ping added,nucleoside                
+230   0.797     4.193    -0.564    -0.282      CM-CM-CA-NC     vinylpyridine - JT-R 2014/04 fit AA t
+230   0.797     4.193    -0.564    -0.282      CM-C=-CA-NC     vinylpyridine - JT-R 2014/04 fit AA t
+231   3.0       3.0       0.0       0.0        C -NC-OH-HO     oxime B3LYP/6-31G*                   
+231   3.0       3.0       0.0       0.0        C -NC-OS-CT     oxime   11/00                        
+232  -3.5       3.0       0.0       0.0        CM-CM-OS-CT     vinyl ether                          
+232  -3.5       3.0       0.0       0.0        C=-CM-OS-CT     vinyl ether                          
+233   0.500     0.0       0.0       0.0        CM-CM-CT-F      allyl CF3                            
+233   0.500     0.0       0.0       0.0        CM-CM-CT-O?     allyl alcohols, ethers               
+233   0.500     0.0       0.0       0.0        C=-CM-CT-O?     allyl alcohols, ethers               
+233   0.500     0.0       0.0       0.0        CM-C=-CT-O?     allyl alcohols, ethers               
+234  -0.9       0.0       0.0       0.0        CM-CT-OH-HO     allyl alcohols                       
+234  -0.9       0.0       0.0       0.0        C=-CT-OH-HO     allyl alcohols                       
+235   0.0000    0.0000    0.3500    0.0        HC-CT-SY-OY     sulfone                              
+235   0.0000    0.0000    0.3500    0.0        HC-CT-SY-OH     sulfonic acid                        
+236   0.0000    0.0000    0.3500    0.0        HC-CT-SY-CT     sulfone                              
+236   0.0000    0.0000    0.3500    0.0        HC-CT-SY-CA     sulfone                              
+237   0.0       0.0       0.0       0.0        CT-CT-SY-CT     sulfone                              
+238   0.0       0.0       0.0       0.0        CT-CT-SY-OY     sulfone                              
+239   0.0       0.0       0.3500    0.0        HC-CT-CT-SY     sulfone                              
+240   0.0       0.0       0.3017    0.0        HC-CT-N3-CT     2ary ammonium                            
+241   1.4379   -0.1238    0.2639    0.0        CT-CT-N3-CT     2ary ammonium                            
+242   0.0       0.0       0.0       0.0        ??-CT-CZ-NZ     nitriles                             
+242   0.0       0.0       0.0       0.0        ??-CA-CZ-NZ     nitriles                             
+242   0.0       0.0       0.0       0.0        ??-C#-CZ-NZ     nitriles                             
+242   0.0       0.0       0.0       0.0        ??-CT-NZ-CZ     isonitriles                          
+242   0.0       0.0       0.0       0.0        HC-CT-NZ-CZ     isonitriles                          
+242   0.0       0.0       0.0       0.0        ??-CA-NZ-CZ     isonitriles                          
+242   0.0       0.0       0.0       0.0        CA-CA-NZ-CZ     isonitriles                          
+243   0.0       0.0       0.0       0.0        ??-CZ-CZ-??     alkynes                              
+244   0.0       0.0       0.0       0.0        ??-CT-CZ-CZ     alkynes                              
+244   0.0       0.0       0.0       0.0        CT-CT-CZ-CZ     alkynes                              
+244   0.0       0.0       0.0       0.0        HC-CT-CZ-CZ     alkynes                              
+244   0.0       0.0       0.0       0.0        HC-CZ-CZ-CT     alkynes                              
+244   0.0       0.0       0.0       0.0        CT-CZ-CZ-CT     alkynes                              
+244   0.0       0.0       0.0       0.0        CM-CZ-CZ-HC     alkynes                              
+244   0.0       0.0       0.0       0.0        CM-CM-CZ-CZ     alkynes                              
+244   0.0       0.0       0.0       0.0        CT-CZ-CZ-CM     alkynes                              
+244   0.0       0.0       0.0       0.0        CT-CZ-CZ-C#     alkynes                              
+244   0.0       0.0       0.0       0.0        HC-CZ-CZ-C#     alkynes                              
+245   0.0      -0.9       0.0       0.0        CA-CA-SY-CT     sulfone 10/00 B3LYP PhSO2Me          
+246  -0.75      0.0       0.0       0.0        CT-SY-OH-HO     sulfonic acid 7/08 B3LYP             
+247   0.75      0.0       0.0       0.0        OY-SY-OH-HO     sulfonic acid 7/08 B3LYP             
+247   0.75      0.0       0.0       0.0        CA-CT-OH-HO     benzyl alcohols  OPLS/2020           
+248   2.0       0.0       0.0       0.0        CA-SY-OH-HO     sulfonic acid 7/08 B3LYP             
+249   0.071     0.0       0.188     0.0        NA-CW-CT-HC     2-alkylpyrrole  JT-R 2014/04 fit AA/C
+250  -1.50     -1.50      0.0       0.0        CR-NA-CT-OS     imidazoles, indoles, purines         
+250  -1.50     -1.50      0.0       0.0        CR-N*-CT-OS     imidazoles, indoles, purines         
+251  -1.50     -1.50      0.0       0.0        CK-NA-CT-OS     imidazoles, indoles, purines         
+251  -1.50     -1.50      0.0       0.0        CK-N*-CT-OS     imidazoles, indoles, purines         
+252   1.50     -1.50      0.0       0.0        C?-NA-CT-OS     imidazoles, indoles, purines         
+252   1.50     -1.50      0.0       0.0        C?-N*-CT-OS     imidazoles, indoles, purines         
+253  -1.00     -0.35      0.0       0.0        CR-NA-CT-CT     imidazoles, indoles, purines         
+253  -1.00     -0.35      0.0       0.0        CR-N*-CT-CT     imidazoles, indoles, purines         
+254  -1.00     -0.35      0.0       0.0        CK-NA-CT-CT     imidazoles, indoles, purines         
+254  -1.00     -0.35      0.0       0.0        CK-N*-CT-CT     imidazoles, indoles, purines         
+255   1.00     -0.35      0.0       0.0        C?-NA-CT-CT     imidazoles, indoles, purines         
+255   1.00     -0.35      0.0       0.0        C?-N*-CT-CT     imidazoles, indoles, purines         
+256  -0.50     -1.50      1.0       0.0        N?-CT-OS-CT     imidazoles, indoles, purines         
+257   0.00     -1.876     0.0       0.0        C?-NA-CT-OS     Ping added for chi in nucleoside     
+258   0.00     -0.576     0.0       0.0        C?-NA-CT-CT     Ping added for ..                    
+259   1.10     -2.2       0.3       0.0        NA-CW-CY-CY     2-cyclopropyl pyrrole JT-R 2014/04 - 
+260   0.0       0.0       0.0       0.0        ??-CY-CY-??     small ring                           
+260   0.0       0.0       0.0       0.0        ??-CY-N$-??     small ring                           
+260   0.0       0.0       0.0       0.0        ??-CY-C$-??     small ring                           
+260   0.0       0.0       0.0       0.0        CY-CY-C$-N$     small ring                           
+260   0.0       0.0       0.0       0.0        CY-CY-C$-O      small ring                           
+260   0.0       0.0       0.0       0.0        ??-CY-S -??     small ring                           
+260   0.0       0.0       0.0       0.0        CY-CY-N$-??     small ring                           
+260   0.0       0.0       0.0       0.0        HC-CY-N$-C?     small ring                           
+260   0.0       0.0       0.0       0.0        HC-CY-C$-O      small ring                           
+260   0.0       0.0       0.0       0.0        HC-CY-C$-SA     small ring JT-R 2014/04 copy for cPr-
+260   0.0       0.0       0.0       0.0        HC-CY-C$-N$     small ring                           
+260   0.0       0.0       0.0       0.0        N -CY-CY-??     small ring                           
+260   0.0       0.0       0.0       0.0        CY-CY-N -H      small ring                           
+260   0.0       0.0       0.0       0.0        C$-CY-N -H      small ring                           
+260   0.0       0.0       0.0       0.0        HC-CY-N -C      small ring                           
+260   0.0       0.0       0.0       0.0        HC-CY-N -H      small ring                           
+260   0.0       0.0       0.0       0.0        C?-N$-CT-C?     small ring                           
+260   0.0       0.0       0.0       0.0        C?-N$-CT-HC     small ring                           
+261   2.300     6.089     0.000     0.0        CY-C$-N$-CT     small ring amides                    
+261   2.300     6.089     0.000     0.0        CY-C$-N$-CY     small ring amides                    
+261   2.300     6.089     0.000     0.0        CY-N -CT-CT     small ring amides                    
+261   2.300     6.089     0.000     0.0        CY-C$-N$-CA     small ring amides                    
+262   0.000     4.900     0.000     0.0        O -C$-N$-H      small ring amides                    
+262   0.000     4.900     0.000     0.0        CY-C$-N$-H      small ring amides                    
+263   0.000     6.089     0.000     0.0        O -C$-N$-CT     small ring amides                    
+263   0.000     6.089     0.000     0.0        O -C$-N$-CA     small ring amides                    
+263   0.000     6.089     0.000     0.0        O -C -N -CY     small ring amides                    
+264  -1.396    -0.427     0.000     0.0        C -N -CY-CY     small ring                           
+264  -1.396    -0.427     0.000     0.0        C -N -CY-C$     small ring                           
+265   0.000    20.000     0.000     0.0        O -C$-N$-CY     small ring amides                    
+266   0.000     0.000     0.000     0.0        HC-CY-CY-HC     small ring                           
+266   0.000     0.000     0.000     0.0        HC-CY-CY-CY     small ring                           
+266   0.000     0.000     0.000     0.0        CT-CY-CY-CY     small ring                           
+266   0.000     0.000     0.000     0.0        CA-CY-CY-CY     small ring                           
+266   0.000     0.000     0.000     0.0        CM-CY-CY-CY     small ring                           
+266   0.000     0.000     0.000     0.0        HC-CY-CY-CT     small ring                           
+266   0.000     0.000     0.000     0.0        HC-CY-CY-CA     small ring                           
+266   0.000     0.000     0.000     0.0        HC-CY-CY-CW     small ring                           
+266   0.000     0.000     0.000     0.0        HC-CY-CY-CM     small ring                           
+266   0.000     0.000     0.000     0.0        CT-CY-CY-CT     small ring                           
+266   0.000     0.000     0.000     0.0        CY-CY-CY-CY     small ring                           
+266   0.000     0.000     0.000     0.0        CA-CY-CY-CT     small ring                           
+266   0.000     0.000     0.000     0.0        CA-CY-CY-CM     small ring                           
+267   0.000     0.000     0.300     0.0        HC-CT-CY-CY     small ring                           
+267   0.000     0.000     0.300     0.0        HC-CT-CY-CT     small ring                           
+268  -0.70      3.60      0.0       0.0        CM-CM-CW-NA     JT-R 2014/04  fit AA/CM1A to MP2/aug-
+269   0.0      -1.5       0.1       0.0        HO-OH-CW-NA     JT-R 2014/04 fit AA/CM1A to MP2/aug-c
+270   0.0       0.0      -0.372     0.0        HC-CT-CM-CM     alkenes all-atom also see 217        
+270   0.0       0.0      -0.372     0.0        HC-CT-C#-C#     alkenes all-atom also see 217        
+270   0.0       0.0      -0.372     0.0        HC-CT-CM-C=     alkenes all-atom also see 217        
+270   0.0       0.0      -0.372     0.0        HC-CT-C=-C=     alkenes all-atom also see 217        
+270   0.0       0.0      -0.372     0.0        HC-CT-C=-CM     alkenes all-atom also see 217        
+270   0.0       0.0      -0.372     0.0        HC-CT-C=-C#     alkenes all-atom also see 217        
+271   0.000     0.000     0.318     0.0        HC-CM-CT-HC     alkene                               
+271   0.000     0.000     0.318     0.0        HC-C#-CT-HC     alkene                               
+272   0.000     0.000     0.366     0.0        HC-CT-CT-CM     alkene                               
+272   0.000     0.000     0.366     0.0        HC-CT-CT-C#     alkene                               
+273   0.000     0.000     0.366     0.0        HC-CT-CT-CZ     alkyne, nitrile                      
+274   0.000    -0.650     0.0       0.0        CT-CT-CT-CZ     alkyne, nitrile                      
+275   0.0       0.0       0.300     0.0        HC-CT-CM-CT     alkenes                              
+275   0.0       0.0       0.300     0.0        HC-CT-C#-CT     alkenes                              
+276   0.0       0.0      -0.250     0.0        HC-CT-CM-C:     allenes B3LYP/631Gdp                 
+277   0.0      -8.0       0.0       0.0        CM-HC-CM-HC     allenes improper                     
+277   0.0      -8.0       0.0       0.0        CM-HC-CM-CT     allenes improper                     
+277   0.0      -8.0       0.0       0.0        CM-CT-CM-HC     allenes improper                     
+277   0.0      -8.0       0.0       0.0        CM-CT-CM-CT     allenes improper                     
+278   0.0       0.0       0.0       0.0        HC-CM-C:-CM     allenes                              
+278   0.0       0.0       0.0       0.0        CT-CM-C:-CM     allenes                              
+279   0.0       1.9       0.0       0.0        CY-CY-CA-CA     cyclopropylbenzene 2014/04  JT-R fit 
+279   0.0       1.9       0.0       0.0        CY-CY-CW-CS     cyclopropylpyrrole 2014/04  JT-R fit 
+280   1.165     0.285     0.0       0.0        CT-OS-CW-NA     2-MeOPyrrole JT-R 2014/04 fit AA/CM1A
+281  -0.95     -4.1       0.0       0.0        HS-SH-CW-NA     2-thio pyrrole JT-R 2014/04fit AA/CM1
+282   1.75     -1.12      0.0       0.74       NA-CW-NT-CT     2-Me2Npyrrole JT-R 2014/04 fit AA+CM1
+283   0.0      -2.24      0.0       0.0        NA-CW-NT-H      2-aminopyrroles JT-R 2014/04 fit AA+C
+284   0.14     -0.09      0.54      0.0        OA-CW-CT-CT     2-alkyl furans  JT-R 2014/04 fit AA+C
+285  -0.129    -0.71      2.18      0.0        CY-CY-CW-OA     2-cyclopropylfuran JT-R 2014/04 fit A
+286   0.0       3.2      -1.3       0.0        CM-CM-CW-OA     2-vinylfuran JT-R 2014/04 fit AA/CM1A
+287   1.3      -1.0       0.33      0.0        OA-CW-OH-HO     2-hydroxyfuran JT-R 2014/04 fit AA/CM
+288   1.5      -0.574     1.3       0.0        OA-CW-OS-CT     2-methoxyfuran JT-R 2014/04 fit AA/CM
+289   0.59     -2.50      0.46      0.0        HS-SH-CW-OA     2-thiolfuran JT-R 2014/04 fit AA/CM1A
+290   0.000     1.000     0.000     0.0        NB-CR-C -O      hetero diketones  4/08               
+291   2.000     1.000     0.000     0.0        NA-CR-C -O      hetero diketones  4/08               
+292   0.000     1.000     0.000     0.0        NB-CR-C -CR     hetero diketones  4/08               
+293  -2.000     1.000     0.000     0.0        NA-CR-C -CR     hetero diketones  4/08               
+294  -0.750     1.500     0.000     0.0        OA-CW-C -O      hetero diketones  4/08               
+295   0.000     1.500     0.000     0.0        OA-CW-C -CW     hetero diketones  4/08               
+296   0.750     1.500     0.000     0.0        CS-CW-C -O      hetero diketones  4/08               
+297   0.000     1.500     0.000     0.0        CS-CW-C -CW     hetero diketones  4/08               
+298   1.2      -2.84      1.2       0.0        OA-CW-S -CT     2-thiomethylfuran JT-R 2014/04 fit AA
+299   0.0      -1.57      0.0       0.0        H -NT-CW-OA     2-aminofuran JT-R fit 2014/04 AA/CM1A
+300  -0.7       4.30      1.1       0.0        CY-CY-CA-NC     cyclopropylpyridine JT-R 2014/04 fit 
+301   0.0       0.0       0.3       0.0        CT-NT-OS-CT     generic hydroxylamines               
+301   0.0       0.0       0.3       0.0        CT-NT-OH-HO     generic                              
+301   0.0       0.0       0.3       0.0        H -NT-OS-CT     generic                              
+301   0.0       0.0       0.3       0.0        H -NT-OH-HO     generic                              
+301   0.0       0.0       0.3       0.0        CT-NT-NT-CT     generic hydrazines                   
+301   0.0       0.0       0.3       0.0        CT-NT-NT-H      generic                              
+301   0.0       0.0       0.3       0.0        H -NT-NT-H      generic                              
+302   2.300     6.089     0.0       0.0        OS-C -N -CT     carbamates                           
+302   2.300     6.089     0.0       0.0        OH-C -N -CT     carbamates                           
+303   0.000     4.900     0.0       0.0        OS-C -N -H      carbamates                           
+303   0.000     4.900     0.0       0.0        OH-C -N -H      carbamates                           
+304  -2.000     5.000     0.0       0.0        N -C -OS-CT     carbamates                           
+305  -2.000     5.000     0.0       0.0        N -C -OH-HO     carbamates                           
+306   0.0       0.0       0.0       0.0        HC-NC-NZ-NZ     azides                               
+306   0.0       0.0       0.0       0.0        CT-NC-NZ-NZ     azides                               
+306   0.0       0.0       0.0       0.0        CT-CT-NC-NZ     azides                               
+307   0.0       0.0       0.0       0.0        HC-CT-C -S=     thiocarbonyl                         
+308  -0.700     5.000     0.000     0.0        S=-C -N -H      thioamides   wlj 01/00; 09/08        
+309   0.000     6.500     0.000     0.0        S=-C -N -CT     thioamides   fit to                  
+310   0.000     6.500     0.000     0.0        S=-C -N -CA     thioamides   MP3/6-31+G**            
+311   0.000     6.500     0.000     0.0        S=-C -N -CM     thioamides   (Wiberg & Rush)         
+312   0.000     5.000     0.000     0.0        S=-C -OS-CT     thioesters   guess                   
+313   0.000     5.500     0.00      0.0        S=-C -OH-HO     thioacids    guess                   
+314   0.000     2.151     0.000     0.295      CT-S -CA-CA     thioanisole JT-R 2014/04 fit AA,CM1A 
+314   0.000     2.660     0.000     0.326      CT-S -CW-CS       copy for methylthiopyrrole JT-R    
+315   0.000     1.300     2.200     0.0        C -N=-C=-CM     azadiene fit to Wiberg MP3           
+316   4.6       0.0       0.0       0.0        N -C -N -CT     alkyl urea   wlj 09/08               
+317   0.0      -1.40      1.30      0.47       OA-CW-NT-CT     2-Me2N-furan JT-R 2014/04 fit AA/CM1A
+318   0.97      0.08      0.14      0.0        SA-CP-CT-HC     2-alkyl thiophenes JT-R 2014/04 fit A
+319   0.0       0.26      0.1       0.0        SA-CP-CT-CT     2-alkyl thiophenes JT-R 2014/04 fit A
+320   0.000     0.500     0.000     0.0        O -C -C -CT     dicarbonyls Kahn & Bruice            
+321   0.000     0.200     0.000     0.0        O -C -C -HC     dicarbonyls BMC 8,1881(2000)         
+322   0.800    -0.760     0.000     0.0        HC-C -C -CT     dicarbonyls    "                     
+323   0.800     0.000     0.000     0.0        HC-C -C -HC     dicarbonyls    "                     
+324   0.700    -1.500     0.000     0.0        CT-C -C -CT     dicarbonyls    "                     
+325   0.000     0.000     0.085     0.0        C -C -CT-HC     dicarbonyls    "                     
+326   0.000     0.000     0.000     0.0        N -C -C -O      dicarbonyls    "                     
+327  -0.900     0.300     0.000     0.0        N -C -C -HC     dicarbonyls    "                     
+328  -0.500     0.200     0.000     0.0        N -C -C -CT     dicarbonyls    "                     
+329   0.400     4.900     0.000     0.0        C -C -N -CT     dicarbonyls    "                     
+330   0.000     4.900     0.000     0.0        H -N -C -C      dicarbonyls    "                     
+331   1.60      3.20      0.0       0.0        O -C -C -O      dicarbonyls    "                     
+332   0.0      -1.04      0.0       0.23       SA-CP-CY-CY     2-cyclopropyl thiophenes JT-R 2014/04
+333   1.19      0.0       0.40      0.0        SA-CP-CY-HC     2-cyclopropyl thiophenes JT-R 2014/04
+334  -2.0       4.2      -0.35      0.0        CM-CM-CP-SA     2-vinyl thiophenes JT-R 2014/04 fit A
+335   2.63     -1.0       0.34      0.0        HO-OH-CP-SA     2-hydroxy thiophenes JT-R 2014/04 fit
+336   0.61      0.0       0.5       0.0        CT-OS-CP-SA     2-methoxy thiophenes JT-R 2014/04 fit
+337   0.79     -3.58      0.3       0.0        HS-SH-CP-SA     2-thiol thiophenes JT-R 2014/04 fit A
+338   0.33     -2.30      0.275     0.0        CT-S -CP-SA     2-thiol thiophenes JT-R 2014/04 fit A
+339   0.0      -1.19      0.0       0.0        H -NT-CP-SA     2-amino thiophenes JT-R 2014/04 fit A
+340  -1.10      0.12      0.0       0.6        CT-NT-CP-SA     2-amino thiophenes JT-R 2014/04 fit A
+341   4.542     6.603     1.045     0.0        CT-C -N -OH     hydroxamic acids                     
+342   0.000     6.603     0.000     0.0        O -C -N -OH     hydroxamic acids                     
+343   5.519    -6.700     0.581     0.0        C -N -OH-HO     hydroxamic acids                     
+344   2.722    -5.154     0.000     0.0        H -N -OH-HO     hydroxamic acids                     
+345   0.0       0.0       0.340     0.0        HC-CT-CW-OA     2-Methyl Furan JT-R 2014/04 fit AA/CM
+346  -1.751     1.606     0.000     0.0        C -CT-CT-CT     Chi-1' Leu OPLS-AA/M                 
+347   2.994     0.252     0.300     0.0        C -CT-CT-CT     Chi-1 Val,Ile OPLS-AA/M              
+348  -1.422     1.068     0.000     0.0        C -CT-CT-CT     Chi-1' Val,Ile OPLS-AA/M             
+349                                                            ** UNASSIGNED **                     
+350   0.000     0.450     0.000     0.0        F -CT-CA-CA     fluoromethyl benzene - Theochem 418(1
+350   0.000     0.450     0.000     0.0        F -CT-CW-??     fluoromethyl aromatic                
+350   0.000     0.450     0.000     0.0        F -CT-CS-??     fluoromethyl aromatic                
+351   0.000    -0.400     0.000     0.0        Cl-CT-CA-CA     chloromethyl benzene - Theochem 418(1
+351   0.000    -0.400     0.000     0.0        Cl-CT-CW-??     chloromethyl aromatic                
+351   0.000    -0.400     0.000     0.0        Cl-CT-CS-??     chloromethyl aromatic                
+352  -0.650     0.000     0.000     0.0        Cl-CT-C -O      2-chloroamide wlj fit to 6-31G*      
+353   0.650     0.000     0.000     0.0        Cl-CT-C -N      2-chloroamide wlj fit to 6-31G*      
+354   1.712     0.725     0.366     0.0        N -CT-CT-CA     Chi-1 Phe, Tyr OPLS-AA/M             
+355  -1.406     1.777     0.000     0.0        C -CT-CT-CA     Chi-1' Phe, Tyr OPLS-AA/M            
+356   0.000     0.000     0.140     0.0        H -Si-Si-H      disilane                             
+357   0.000     0.000     0.100     0.0        CT-Si-Si-H      disilane                             
+358   1.000    -0.200     0.000     0.0        CT-Si-Si-CT     disilane                             
+359   0.000     0.000     0.140     0.0        HC-CT-Si-Si     disilane                             
+360   0.000     0.000     0.180     0.0        HC-CT-Si-H      silane  silaethane                   
+361   0.000     0.000     0.260     0.0        CT-CT-Si-H      silane  1-silapropane                
+361   0.000     0.000     0.260     0.0        CA-CA-Si-H      silane                               
+362   0.000     0.000     0.180     0.0        CT-Si-CT-HC     silane  2-silapropane                
+363   0.000     0.000     0.260     0.0        Si-CT-CT-HC     silane  1-silapropane                
+364   0.400     0.000     0.200     0.0        CT-CT-CT-Si     silane  1-silabutane                 
+365   0.800     0.000     0.200     0.0        CT-CT-Si-CT     silane  2-silabutane                 
+366                                                            ** UNASSIGNED **                     
+367   5.200    -0.500     0.000     0.0        Si-CT-CT-Si     silane                               
+368   0.000     0.000     0.180     0.0        H -Si-OH-HO     tentative                            
+369   0.000     0.000     0.180     0.0        H -Si-OS-CT     tentative                            
+370   0.000     0.000     0.180     0.0        CT-Si-OH-HO     tentative                            
+371   1.000     0.000     0.000     0.0        CT-Si-OS-CT     tentative                            
+372   0.000     0.000     0.180     0.0        HC-CT-Si-OH     silane  silanol                      
+373   0.000     0.000     0.180     0.0        HC-CT-Si-OS     silane  silanol                      
+374   0.000     0.000     0.180     0.0        HC-CT-OS-Si     silane  silyl ether                  
+375                                                            ** UNASSIGNED **                     
+376   0.000     0.000     0.000     0.0        OS-Si-OS-Si     tentative                            
+377   0.000     0.000     0.000     0.0        Si-OS-Si-CT     tentative                            
+378   0.000     0.000     0.180     0.0        H -Si-OH-HO     tentative                            
+379                                                            ** UNASSIGNED **                     
+380   0.0       4.7       0.0       0.0        CT-OS-CA-NC     2-methoxypyridine  JT-R 2014/04 fit C
+381   1.51      4.0       0.7       0.0        CT-S -CA-NC     2-thiomethylpyridine JT-R 2014/04 fit
+382   0.0       0.0       0.418     0.183      CT-CT-CA-NC     2-ethylpyridine JT-R 2014/04 fit AA t
+383   0.0       5.2       0.0       0.0        CT-OS-CQ-NC     diazine                              
+384   0.0       4.8       0.0       0.0        CT-S -CQ-NC     diazine                              
+385   0.0       0.5      -0.5       0.0        CT-CT-CQ-NC     diazine                              
+386   0.556    -3.865     0.0       0.0        CT-S -CW-NA     2-thiomethoxypyrrole JT-R 2014/04 fit
+387  -0.588     1.020     0.665     0.0        N -CT-CT-C*     Chi-1  Trp OPLS-AA/M                 
+388  -0.506     0.975     0.000     0.0        C -CT-CT-C*     Chi-1' Trp OPLS-AA/M                 
+389  -0.542     0.435     0.000     0.0        N -CT-CT-CV     Chi-1  Hie OPLS-AA/M                 
+389  -0.542     0.435     0.000     0.0        N -CT-CT-CW     Chi-1  Hid OPLS-AA/M                 
+390  -1.282     1.645    -0.017     0.0        C -CT-CT-CV     Chi-1' Hie OPLS-AA/M                 
+390  -1.282     1.645    -0.017     0.0        C -CT-CT-CW     Chi-1' Hie OPLS-AA/M                 
+391  -3.038     0.419     0.000     0.0        N -CT-CT-CX     Chi-1  Hip OPLS-AA/M                 
+392  -1.708     1.516    -0.502     0.0        C -CT-CT-CX     Chi-1' Hip OPLS-AA/M                 
+393   0.214     0.541     0.392     0.0        N -CT-CT-CT     Chi-1  Met OPLS-AA/M                 
+394  -0.911     0.699     0.000     0.0        C -CT-CT-CT     Chi-1' Met OPLS-AA/M                 
+395  -7.890     0.662     0.997     0.0        N -CT-CT-C      Chi-1  Asp,Ash OPLS-AA/M             
+396   1.543     0.696     0.000     0.0        C -CT-CT-C      Chi-1' Asp,Ash OPLS-AA/M             
+397  -5.501     1.527     0.000     0.0        N -CT-CT-C      Chi-1  Asn OPLS-AA/M                 
+398   0.598     1.558     0.255     0.0        C -CT-CT-C      Chi-1' Asn OPLS-AA/M                 
+399   1.987     0.457     0.820     0.0        N -CT-CT-CT     Chi-1  Glu OPLS-AA/M                 
+400  -1.764     0.700     0.000     0.0        C -CT-CT-CT     Chi-1' Glu OPLS-AA/M                 
+401   0.884     0.897     0.880     0.0        N -CT-CT-CT     Chi-1  Gln,Glh,Lys,Lyn,Arn OPLS-AA/M 
+402  -2.538     0.911     0.000     0.0        C -CT-CT-CT     Chi-1' Gln,Glh,Lys,Lyn,Arn OPLS-AA/M 
+403   0.103     0.653     0.563     0.0        N -CT-CT-CT     Chi-1  Arg OPLS-AA/M                 
+404  -1.971     0.770     0.000     0.0        C -CT-CT-CT     Chi-1' Arg OPLS-AA/M                 
+405  -0.940     2.755    -2.670     0.0        N -CT-C -N      Psi  Pro OPLS-AA/M                   
+406   5.029     0.719     2.240     0.0        CT-CT-C -N      Psi' Pro OPLS-AA/M                   
+407   1.572     0.159     0.200     0.0        N -CT-CT-CT     Chi-1  Pro OPLS-AA/M                 
+408  -1.751     1.606     0.000     0.0        C -CT-CT-CT     Chi-1' Pro OPLS-AA/M                 
+409   1.494    -0.511     0.125     0.0        CT-CT-C -N      Chi-2  Asn OPLS-AA/M                 
+410   1.656     1.304     0.439     0.0        CT-CT-C -O      Chi-2' Asn OPLS-AA/M                 
+411   0.000     1.000     1.350     0.0        CT-CT-C -O2     Chi-2  Asp OPLS-AA/M                 
+412  -1.267     0.479    -0.486     0.0        CT-CT-CT-C      Chi-2  Gln OPLS-AA/M                 
+413  -0.885     1.025    -1.293     0.0        CT-CT-CT-C      Chi-2  Glu OPLS-AA/M                 
+414  -0.560    -0.740     0.349     0.0                        Chi-2  Hid, Hie OPLS-AA/M            
+415  -3.990     1.680     0.290     0.0                        Chi-2  Hip      OPLS-AA/M            
+416                                                            ** UNASSIGNED **                     
+417                                                            ** UNASSIGNED **                     
+418                                                            ** UNASSIGNED **                     
+419                                                            ** UNASSIGNED **                     
+420                                                            ** UNASSIGNED **                     
+421                                                            ** UNASSIGNED **                     
+422  -0.400    -0.300     0.500     0.0        CW-CU-C!-CA     biaryl 4-pyridyltriazole djc 3/15    
+423   0.0       1.65      0.0      -0.05       CA-C!-C!-CA     biaryl_1      CCSD-compromise (sue, m
+424   0.0       2.01      0.0       0.0        CA-C!-C!-NC     biaryl_3                             
+424   0.0       2.01      0.0       0.0        C=-C!-C!-NC     biaryl_22                            
+424   0.0       2.01      0.0       0.0        C#-C!-C!-NC     biaryl_22                            
+425   0.0       1.11      0.0      -0.13       NC-C!-C!-NC     biaryl_12 keep V4                    
+426   0.0       1.49      0.0       0.0        CA-C!-CS-CW     biaryl_4                             
+426   0.0       1.49      0.0       0.0        CA-C!-CW-CS     biaryl_5                             
+426   0.0       1.49      0.0       0.0        CA-C!-CP-CS     biaryl_5                             
+426   0.0       1.49      0.0       0.0        CA-C!-CS-CP     biaryl_5                             
+426   0.0       1.49      0.0       0.0        CA-C!-CS-CS     biaryl_3,4                           
+426   0.0       1.49      0.0       0.0        C=-C!-CS-CS     biaryl_23-28                         
+426   0.0       1.49      0.0       0.0        C=-C!-CS-CW     biaryl_23-28                         
+426   0.0       1.49      0.0       0.0        C=-C!-CW-CS     biaryl_23-28                         
+426   0.0       1.49      0.0       0.0        C=-C!-CS-CP     biaryl_23-28                         
+426   0.0       1.49      0.0       0.0        C=-C!-CP-CS     biaryl_23-28                         
+426   0.0       1.49      0.0       0.0        C#-C!-CS-CS     biaryl_23-28                         
+426   0.0       1.49      0.0       0.0        C#-C!-CS-CW     biaryl_23-28                         
+426   0.0       1.49      0.0       0.0        C#-C!-CW-CS     biaryl_23-28                         
+426   0.0       1.49      0.0       0.0        C#-C!-CS-CP     biaryl_23-28                         
+426   0.0       1.49      0.0       0.0        C#-C!-CP-CS     biaryl_23-28                         
+427   0.0       1.73      0.0       0.0        CA-C!-CW-OS     biaryl_6                             
+427   0.0       1.73      0.0       0.0        C=-C!-CW-OS     biaryl_25                            
+427   0.0       1.73      0.0       0.0        C#-C!-CW-OS     biaryl_25                            
+428                                                            ** UNASSIGNED **                     
+429   0.0       1.33      0.0       0.0        CA-C!-CP-S      biaryl_7                             
+429   0.0       1.33      0.0       0.0        C=-C!-CP-S      biaryl_26                            
+429   0.0       1.33      0.0       0.0        C#-C!-CP-S      biaryl_26                            
+430                                                            ** UNASSIGNED **                     
+431   0.0       2.0       0.0       0.0        CA-C!-CW-NA     biaryl_7                             
+431   0.0       2.0       0.0       0.0        CA-C!-CR-NA     biaryl_9                             
+431   0.0       2.0       0.0       0.0        C=-C!-CW-NA     biaryl_27                            
+431   0.0       2.0       0.0       0.0        C=-C!-CR-NA     biaryl_29                            
+431   0.0       2.0       0.0       0.0        C#-C!-CW-NA     biaryl_27                            
+431   0.0       2.0       0.0       0.0        C#-C!-CR-NA     biaryl_29                            
+432   0.0       3.01      0.0       0.22       CA-C!-CW-NS     biaryl_8  keep V4                    
+432   0.0       3.01      0.0       0.22       C=-C!-CW-NS     biaryl_28 keep V4                    
+432   0.0       3.01      0.0       0.22       C#-C!-CW-NS     biaryl_28 keep V4                    
+433   0.0       1.59      0.0       0.0        CA-C!-CR-NB     biaryl_10                            
+433   0.0       1.59      0.0       0.0        CA-C!-CV-NB     4-phenyltriazole                     
+433   0.0       1.59      0.0       0.0        C=-C!-CR-NB     biaryl_29                            
+433   0.0       1.59      0.0       0.0        C#-C!-CR-NB     biaryl_29                            
+434   0.0       1.47      0.0      -0.07       CA-C!-NX-CW     biaryl_10                            
+434   0.0       1.47      0.0      -0.07       C=-C!-NX-CW     biaryl_30                            
+434   0.0       1.47      0.0      -0.07       C#-C!-NX-CW     biaryl_30                            
+435   0.0       1.76      0.0       0.0        CA-C!-NX-NB     biaryl_11                            
+436   0.0       1.95      0.0       0.0        NC-C!-CS-CS     biaryl_13-18                         
+436   0.0       1.95      0.0       0.0        NC-C!-CS-CW     biaryl_13-18                         
+436   0.0       1.95      0.0       0.0        NC-C!-CW-CS     biaryl_13-18                         
+436   0.0       1.95      0.0       0.0        NC-C!-CS-CP     biaryl_13-18                         
+436   0.0       1.95      0.0       0.0        NC-C!-CP-CS     biaryl_13-18                         
+437   0.0       2.29      0.0       0.0        NC-C!-CW-OS     biaryl_15                            
+438                                                            ** UNASSIGNED **                     
+439   0.0       2.65      0.0       0.0        NC-C!-CP-S      biaryl_16                            
+440   0.0       3.33      0.0       0.0        NC-C!-CW-NA     biaryl_17                            
+440   0.0       3.33      0.0       0.0        NC-C!-CR-NA     biaryl_17                            
+441   0.0       1.03      0.0       0.0        NC-C!-CR-NB     biaryl_19                            
+441   0.0       1.03      0.0       0.0        NC-C!-CV-NB     2-pyridinyl-4-triazole               
+442   0.0       3.7       0.0       0.0        NC-C!-CW-NS     biaryl_18                            
+443   0.0       2.49      0.0       0.0        NC-C!-NX-CW     biaryl_20                            
+444   0.0       2.84      0.0       0.0        NC-C!-C!-NA     biaryl_22                            
+445   0.0       1.6       0.0      -0.18       CA-C!-C!-NA     biaryl_21 keep V4                    
+446   0.0       1.28      0.65     -0.23       CW-NX-C!-NA     biaryl_30                            
+447   2.75      1.21      1.09      0.0        CS-CS-C!-NA     biaryl_23,24                         
+447   2.75      1.21      1.09      0.0        CS-CW-C!-NA     biaryl_25-27                         
+448   2.8       2.1       1.3       0.0        OS-CW-C!-NA     biaryl_25                            
+449                                                            ** UNASSIGNED **                     
+450   7.33      2.18      0.51      0.0        NA-C!-CW-NA     biaryl_27                            
+450   7.33      2.18      0.51      0.0        NA-C!-CR-NA     biaryl_29                            
+451   6.25      1.78      1.43      0.0        NA-C!-CW-NS     biaryl_28                            
+452   4.0       2.13      1.6       0.0        NA-C!-CR-NB     biaryl_29                            
+453                                                            ** UNASSIGNED **                     
+454   0.63      0.8       1.54     -0.74       NA-C!-CP-S      biaryl_26 keep V4                    
+455   0.0       1.87      0.00     -0.18       H -N2-CR-NA     aminoimidazol                        
+456   0.0       1.76      0.0       0.23       CA-C!-N -C      biaryl_62                            
+457   1.5       1.5       0.87      0.0        CW-CS-C!-NA     biaryl_23                            
+458   2.91      1.83      1.21      0.0        NA-C!-CS-CP     biaryl_24                            
+458   2.91      1.83      1.21      0.0        NA-C!-CP-CS     biaryl_26                            
+459                                                            ** UNASSIGNED **                     
+460   3.25      2.16      1.28      0.36       CA-OS-CA-CA     biaryl_ether_1                       
+461                                                            ** UNASSIGNED **                     
+462                                                            ** UNASSIGNED **                     
+463  -3.76      5.03      0.61      0.46       NC-CA-OS-CA     biaryl_ether_15_scan_1_Phi1          
+464  -0.71      2.1      -1.83      0.0        C -N -CY-CY     biaryl_ether_15_scan_2               
+465                                                            ** UNASSIGNED **                     
+466   4.64     -1.27      0.45      0.08       NE-CT-CT-CT     alkyl_hydantoin                      
+467  -4.16     -0.76      0.96      0.16       C -CT-CT-CT     alkyl_hydantoin                      
+468                                                            ** UNASSIGNED **                     
+469                                                            ** UNASSIGNED **                     
+470  -0.92      5.10      0.0       0.0        NC-CA-NT-CT     2-NMe2-pyridine JT-R 2014/04 fit AA/C
+471                                                            ** UNASSIGNED **                     
+472                                                            ** UNASSIGNED **                     
+473                                                            ** UNASSIGNED **                     
+474                                                            ** UNASSIGNED **                     
+475   0.0       1.1       2.59      0.47       CA-CA-CT-N      VHL_compounds                        
+476   0.34     -0.27      0.63      0.0        OS-CW-CT-C      VHL_2                                
+477   0.08     -0.16     -0.33      0.43       CS-CW-CT-C      VHL_2                                
+478   3.42      0.2      -2.51      0.0        CR-NA-CT-C      VHL_5                                
+479   1.82     -0.78     -1.92      0.0        CW-NA-CT-C      VHL_5                                
+480  -3.5       5.0       0.0       0.0        CM-CM-OS-CA     phenyl vinyl ether  wlj 1/19         
+481   0.000     0.000     0.000     0.0        OY-SY-CM-CM     vinylsulfone wlj 2/22                
+481   0.000     0.000     0.000     0.0        OY-SY-CM-HC     vinylsulfone wlj 2/22                
+482   0.500     0.000     0.000     0.0        CA-SY-CM-CM     vinylsulfone wlj 2/22                
+482   0.500     0.000     0.000     0.0        CB-SY-CM-CM     vinylsulfone wlj 2/22                
+482   0.500     0.000     0.000     0.0        CT-SY-CM-CM     vinylsulfone wlj 2/22                
+483   0.000     0.000     0.000     0.0        CA-SY-CM-HC     vinylsulfone wlj 2/22                
+483   0.000     0.000     0.000     0.0        CB-SY-CM-HC     vinylsulfone wlj 2/22                
+483   0.000     0.000     0.000     0.0        CT-SY-CM-HC     vinylsulfone wlj 2/22                
+483                                                            ** UNASSIGNED **                     
+484                                                            ** UNASSIGNED **                     
+485   1.000     2.000     1.000     0.0        CY-CY-CM-CM     vinylcyclopropane 6/23              
+486   0.000     0.500     0.000     0.0        HC-CY-CM-CM     vinylcyclopropane 6/23              
+487   0.000     0.500     0.000     0.0        CT-CY-CM-CM     vinylcyclopropane 6/23              
+488   0.000     0.500     0.000     0.0        HC-CY-CM-HC     vinylcyclopropane 6/23              
+489                                                            ** UNASSIGNED **                     
+490                                                            ** UNASSIGNED **                     
+491                                                            ** UNASSIGNED **                     
+492                                                            ** UNASSIGNED **                     
+493                                                            ** UNASSIGNED **                     
+494                                                            ** UNASSIGNED **                     
+495                                                            ** UNASSIGNED **                     
+496                                                            ** UNASSIGNED **                     
+497                                                            ** UNASSIGNED **                     
+498                                                            ** UNASSIGNED **                     
+499                                                            ** UNASSIGNED **                     
+500   0.0       0.0       0.0       20.        Harmonic Restraint - Do Not Remove.                  
+602  -7.4       3.0       1.8       0.0        C3-C2-OS-C2     UA ether   with scl14 = 2,2         
+603  -8.4       3.0       1.8       0.0        C3-C2-OS-C3     UA ether   with scl14 = 2,2         
+604  -3.400     1.250     3.100     0.0        C2-C2-C2-C2     UA alkanes with scl14 = 2,2         
+604  -3.400     1.250     3.100     0.0        C3-C2-C2-C2     UA alkanes with scl14 = 2,2         
+604  -3.400     1.250     3.100     0.0        C3-C2-C2-C3     UA alkanes with scl14 = 2,2         
+604  -3.400     1.250     3.100     0.0        CH-C2-C2-C2     UA alkanes with scl14 = 2,2         
+604  -3.400     1.250     3.100     0.0        CH-C2-C2-CH     UA alkanes with scl14 = 2,2         
+604  -3.400     1.250     3.100     0.0        CT-C2-C2-C2     UA alkanes with scl14 = 2,2         
+604  -3.400     1.250     3.100     0.0        C2-CH-C2-C2     UA alkanes with scl14 = 2,2         
+604  -3.400     1.250     3.100     0.0        C2-CT-C2-C2     UA alkanes with scl14 = 2,2         
+610   0.300     0.000     1.300     0.0        C3-C2-OH-HO     Alcohols   with scl14 = 2,2         
+611   0.300     0.000     1.300     0.0        C2-C2-OH-HO     Alcohols   with scl14 = 2,2         
+611   0.300     0.000     1.300     0.0        CH-C2-OH-HO     Alcohols   with scl14 = 2,2         
+612   0.300     0.000     0.500     0.0        C3-CH-OH-HO     Alcohols   with scl14 = 2,2         
+612   0.300     0.000     0.500     0.0        C2-CH-OH-HO     Alcohols   with scl14 = 2,2         
+613   0.0       0.0       0.200     0.0        C3-CT-OH-HO     Alcohols   with scl14 = 2,2         
+613   0.0       0.0       0.200     0.0        C2-CT-OH-HO     Alcohols   with scl14 = 2,2         
+614  -2.500     1.250     3.100     0.0        C2-C2-C2-O?     UA etherol with scl14 = 2,2         
+614  -2.500     1.250     3.100     0.0        C3-C2-C2-O?     UA etherol with scl14 = 2,2         
+615  -2.500     1.250     3.100     0.0        C2-CH-C2-O?     UA etherol with scl14 = 2,2         
+620  -2.000     0.500     3.250     0.0        C2-C2-C2-Br     UA bromoalkane "    "    "           
+620  -2.000     0.500     3.250     0.0        C3-C2-C2-Br     UA bromoalkane "    "    "           
+621  -2.000     0.700     3.000     0.0        C2-C2-C2-F      UA fluoroalkane "    "    "          
+621  -2.000     0.700     3.000     0.0        C3-C2-C2-F      UA fluoroalkane "    "    "          
+# R4 Parameters for Cation-Pi Interactions                                                          
+# Cations  (Type, Kappa) A2, F8.2 - 5 per line                                                      
+# Li  0.45  Na  0.70  K   0.95  Rb   0.70 Cs   0.75                                                 
+# N3  1.00  N2  0.25  C+  0.00  P+   1.0                                                            
+#                                                                                                   
+#                                                                                                   
+# Pi atoms (Type, Alpha) A2, F8.2 - 5 per line                                                      
+# CA 190.0  CB 190.0  CK 210.0  CU 210.0  CV 210.0                                                  
+# CW 210.0  CR 210.0  CQ 190.0  CP 200.0  NA 150.0                                                  
+# NB 180.0  NC 100.0  NH 150.0  NS 150.0  NX 150.0                                                  
+# CS 210.0  OA 150.0  SA  50.0  C! 190.0                                                            
+                                                                                                    

--- a/moltemplate/force_fields/convert_OPLSAA_to_LT/Jorgensen_et_al-2024-The_Journal_of_Physical_Chemistry_B.sup-3.txt
+++ b/moltemplate/force_fields/convert_OPLSAA_to_LT/Jorgensen_et_al-2024-The_Journal_of_Physical_Chemistry_B.sup-3.txt
@@ -1,0 +1,3589 @@
+*****                         OPLS-UA and OPLS-AA     Oct  1, 2023
+*****                         Bond Stretching and Angle Bending Parameters *****
+OW-HW 600.00     0.9572       For TIP4F Water - wlj 1/98  
+OW-LP 900.00     0.1750              "
+***** 529.60     0.9572       J Phys Chem 91, 3349 (1987) for TIP3F (OW-HW)
+*****  38.25     1.5139          "        "      "        for TIP3F (HW-HW)
+C*-HC 340.       1.08
+C -C2 317.       1.522        GLY,ASP,GLU
+C -C3 317.       1.522        END
+C -CA 400.       1.490        wlj 8/97
+C -CV 400.       1.490        wlj 6/14
+C -CB 447.       1.419        GUA
+C -CD 469.       1.40         TYR
+C -CH 317.       1.522        AA
+C -CJ 410.       1.444        URA
+C -CM 410.       1.444        THY
+C -CT 317.       1.522
+C$-CY 317.       1.522        wlj
+C$-N$ 490.       1.335        wlj
+C -N  490.       1.335        AA
+C -NM 490.       1.335        AA
+C -N* 424.       1.383        CYT,URA
+C -NA 418.       1.388        URAGUA
+C -NC 457.       1.358        CYT
+C -N= 457.       1.290        imine
+C=-NC 457.       1.290        imine
+C#-NC 457.       1.290        imine
+C -O  570.       1.229        URAGUA,CYT,AA
+C$-O  570.       1.229        wlj             
+C -O2 656.       1.25         GLU,ASP
+C -OH 450.       1.364        TYR
+C -S= 400.       1.640        wlj thioamide, etc.
+NO-ON 550.       1.225        wlj nitro
+CT-NO 375.       1.490        wlj nitro
+CA-NO 400.       1.460        wlj nitro
+N -ON 500.       1.270        wlj pyridine N-oxide
+NC-ON 550.       1.210        wlj nitroso         
+CA-OH 450.       1.364
+CA-OS 450.       1.364        wlj
+CB-OS 340.       1.360        wlj
+CM-OS 450.       1.370        wlj
+CM-OH 450.       1.370        wlj
+C -OS 214.       1.327        J.Comp.Chem.1990,11,1181 SKF8
+C*-C2 317.       1.495        TRP(OL)
+C*-CB 388.       1.459        TRP
+C*-CG 546.       1.352        TRP
+C*-CC 546.       1.352        TRP
+C*-CT 317.       1.495        TRP(OL)
+CS-CT 317.       1.495        wlj
+C*-CW 546.       1.352        TRP
+CA-CW 546.       1.367        pyrrole - wlj
+CU-CS 469.       1.424        wlj
+CS-CW 546.       1.367        wlj/nm
+CS-CS 469.       1.424         "
+CS-CB 469.       1.424         "
+CS-HA 367.       1.080         "
+CU-NB 410.       1.320         "
+CU-CA 469.       1.421         "
+CU-HA 367.       1.080         "
+NA-NB 400.       1.349         "
+NB-NB 400.       1.280         " could be N-N or N=N
+OS-NB 462.       1.399         "
+OA-NB 462.       1.399         "
+OS-CR 462.       1.357         "
+OA-CR 462.       1.357         "
+C2-C2 260.       1.526        AA(OL)
+C2-C3 260.       1.526        ILE(OL)
+C3-C3 260.       1.526        Ethane
+C2-CA 317.       1.51         PHE,TYR
+C2-CD 317.       1.51         PHE,TYR
+C2-CC 317.       1.504        HIS
+C2-CH 260.       1.526        AA,SUG
+C2-N  337.       1.449        GLY(OL)
+C2-N2 337.       1.463        ARG(OL)
+C2-N3 367.       1.471        LYS(OL)
+CH-NT 382.       1.448        wlj - MM3 based
+C2-NT 382.       1.448        JACS 112, 8314 (90)
+C3-NT 382.       1.448         " 
+CT-NT 382.       1.448         "
+NT-NT 350.       1.430        wlj revised 1/14
+C2-OH 386.       1.425         SUG(OL),SER
+C2-OS 320.       1.425         SUG(OL)
+CO-OS 320.       1.38         Acetal - wlj 2/93
+CO-C2 260.       1.526          "
+CO-C3 260.       1.526          "
+CW-OS 340.       1.36         Furan  - wlj 4/97
+CW-OA 340.       1.36         JT-R 2014/04 Furan  - wlj 4/97
+CP-OS 340.       1.356        JT-R 2014/04 thiophene ethers
+CP-SH 220.       1.763        JT-R 2014/04 thiophene thiol
+C2-S  222.       1.81         CYX(OL)
+C2-SH 222.       1.81         CYS(OL)
+C3-CH 260.       1.526        ALA
+C3-CM 317.       1.51         THY(use std C-C)
+C3-N  337.       1.449        est      
+C3-N* 337.       1.475        9 methyl bases
+C3-N2 337.       1.463        ARG(OL)
+C3-N3 367.       1.471
+C3-OH 386.       1.425         SUG(OL),SER
+C3-OS 320.       1.425          DMP
+C3-S  222.       1.81         MET(OL)
+C3-SH 222.       1.81         CYS(OL)
+CA-CA 469.       1.40         TRP,TYR,PHE
+CA-C! 469.       1.40  
+CB-C! 469.       1.40  
+C!-C! 385.       1.460        wlj
+C!-CS 385.       1.460        wlj
+C!-CU 385.       1.460        wlj
+C!-CV 385.       1.460        wlj
+C!-CW 385.       1.460        wlj
+C!-CR 385.       1.460        wlj
+C!-C  385.       1.460        wlj
+C!-CM 385.       1.460        wlj
+C!-NA 427.       1.381        MKD changed from 1.440 to 1.381
+CA-CB 469.       1.404        ADE
+CA-CD 469.       1.40         PHE,TYR
+CA-CJ 427.       1.433        CYT
+CA-CM 427.       1.433
+CA-C= 427.       1.433
+CA-C# 427.       1.433
+CA-CN 469.       1.40         TRP
+CA-CT 317.       1.51         PHE,TYR
+CA-CY 317.       1.49         wlj
+CW-CY 317.       1.465        wlj,  JT-R 2014/04 copy for cyclopropyl-heterocycle
+CW-CT 278.       1.488        jpt   changed from 317. 1.504        jtr: HID CB-CG
+CP-CT 278.       1.496        JT-R 2014/04  2-alkyl thiophenes, MP2/aug-cc-pVTZ
+CP-OH 278.       1.366        JT-R 2014/04  2-alkyl thiophenes, MP2/aug-cc-pVTZ
+CV-CT 317.       1.504        jtr: HIE CB-CG
+CX-CT 317.       1.504        jtr: HIP CB-CG
+CX-CX 520.       1.370        copy from CV-CW for HIP
+CX-NA 427.       1.381        jtr - HIP
+CX-HA 367.       1.08         jtr - HIP
+CA-NY 382.       1.385        jtr - neutral Arg; MLL
+NY-H  434.       1.01         jtr - neutral Arg; MLL
+NC-H  434.       1.01         jtr - neutral Arg; MLL
+CT-NY 382.       1.448        jtr - neutral Arg; MLL
+CA-N2 481.       1.340        ARG
+CQ-N2 481.       1.340        wlj
+CR-N2 481.       1.340        wlj
+C=-N2 481.       1.340        wlj
+C=-N  481.       1.340        wlj
+CA-NT 481.       1.340        wlj/rr anilines
+CW-NT 481.       1.385        JT-R 2014/04 2-amino pyrroles, furans
+CP-NT 481.       1.380        JT-R 2014/04 2-amino thiophenes 
+CW-CM 481.       1.454        JT-R 2014/04 2-vinyl furans
+CW-C= 481.       1.454        JT-R 2014/04 2-vinyl furans
+CA-NA 427.       1.381        GUA
+CQ-N  427.       1.381        wlj
+CA-NC 483.       1.339        ADE,GUA,CYT
+CM-NC 483.       1.339        ADE,GUA,CYT
+C!-NC 483.       1.339        wlj        
+NC-NC 500.       1.320        wlj pyridazine
+NC-NZ 550.       1.24         wlj  azide
+NZ-NZ 550.       1.13         wlj  azide & diazo
+C -NZ 400.       1.29         wlj 07/11  diazo       
+CS-NZ 400.       1.29         wlj 07/11  diazo       
+CT-NZ 390.       1.430        wlj 10/04  isonitrile
+CA-NZ 400.       1.410        wlj 10/04  isonitrile
+CA-HA 367.       1.080        PHE, etc.
+CB-CB 520.       1.370        ADE,GUA
+CB-CV 520.       1.410        ADE,GUA
+CR-CS 520.       1.370        wlj
+CV-CW 520.       1.370        wlj imidazole
+CU-CW 520.       1.370        wlj            
+CB-CD 469.       1.40         TRP
+CB-CN 447.       1.419        TRP
+CB-N* 436.       1.374        ADE,GUA
+CB-NA 436.       1.374        wlj
+CB-NB 414.       1.391        ADE,GUA,HIS
+CB-NC 461.       1.354        ADE,GUA
+CR-NC 461.       1.354        wlj
+CC-CF 512.       1.375        HIS
+CC-CG 518.       1.371        HIS
+CC-CT 317.       1.504        HIS
+CC-CV 512.       1.375        HIS
+CW-CW 512.       1.375
+CC-CW 518.       1.371        HIS
+CC-NA 422.       1.385        HIS
+CC-NB 410.       1.394        ADE,GUA,HIS
+CD-CD 469.       1.40         TRP,TYR,PHE
+CD-CN 469.       1.40         TRP
+CA-CC 469.       1.40         TRP
+CD-CC 469.       1.40         TRP
+CE-N* 440.       1.371        ADE,GUA
+CE-NB 529.       1.304        ADE,GUA
+CF-NB 410.       1.394        ADE,GUA,HIS
+CG-NA 427.       1.381        TRP,HIS
+CH-CH 260.       1.526        SUG(as in CH-C2),ILE
+CH-N  337.       1.449        AA
+CH-N* 337.       1.475        ADE,GUA,CYT,URA
+CH-OH 386.       1.425        RSUG,THR
+CH-OS 320.       1.425        SUG
+CI-NC 502.       1.324        ADE
+CJ-CJ 549.       1.350        URA,CYT
+CJ-CM 549.       1.350        THY
+CJ-N* 448.       1.365        URA,CYT
+CK-HA 340.       1.08
+CK-H5 367.       1.08
+CK-N* 440.       1.371
+CK-NA 440.       1.371
+CK-NB 529.       1.304
+C:-CM 700.       1.305        wlj 9/06 allene
+C:-O  700.       1.168        wlj 9/06 ketene and CO2
+CM-CM 549.       1.340        wlj
+CM-C= 549.       1.340        wlj 
+C#-C# 549.       1.345        wlj
+C#-C! 549.       1.365        wlj 4/13
+CW-C= 549.       1.365
+C=-C= 385.       1.460        wlj 1,3-diene 3/97
+C#-C= 385.       1.460        wlj 1,3-triene 6/08
+CM-CZ 400.       1.426        wlj 9/06               
+C=-CZ 400.       1.426        wlj 9/06               
+C -CZ 400.       1.444        wlj 9/06
+C#-CZ 400.       1.444        wlj     
+C=-N= 415.       1.428        wlj azadiene 9/02
+C -C  350.       1.510        wlj oxalic acid, etc.
+C=-C  385.       1.460        wlj acrolein
+CT-C+ 532.8      1.460        wlj - JACS 94, 4632 (1972)
+C+-HC 532.8      1.084        wlj -      "
+CM-CT 317.       1.51         wlj
+C=-CT 317.       1.51         wlj
+C#-CT 317.       1.51         wlj
+CM-HC 340.       1.08         wlj
+C=-HC 340.       1.08         wlj
+C#-HC 340.       1.08         wlj
+CM-HA 340.       1.08         wlj
+C=-HA 340.       1.08         wlj
+C#-HA 340.       1.08         wlj
+CM-H4 367.       1.08  
+C=-HC 340.       1.08         wlj
+HC-C  340.       1.09         wlj 7/96
+CT-CZ 390.       1.470        wlj 9/98 do 11/98
+CA-CZ 400.       1.451        wlj 9/98
+CU-CZ 400.       1.451        wlj 6/08
+CY-CZ 400.       1.436        wlj 6/23
+CZ-NZ 650.       1.157        wlj 9/98
+CZ-CZ 1150.      1.210        do 11/98 - JPOC, 9, 191 (1996)
+HC-CZ 420.       1.080        do 01/99 - JPOC, 9, 191 (1996)
+CM-N* 448.       1.365
+CM-NA 448.       1.365        copy from above for CytH+ (jtr 5-14-91)
+CN-NA 428.       1.38         TRP
+CP-NA 477.       1.343        HIS
+CP-NB 488.       1.335        HIS(MOD)
+CQ-HA 367.       1.08
+CQ-H5 367.       1.08
+CQ-NC 502.       1.324
+CR-HA 367.       1.08
+CR-H5 367.       1.08
+CR-NA 477.       1.343        HIS
+CR-NS 477.       1.343        HIS
+CR-NX 477.       1.343        HIS
+CR-NB 488.       1.335        HIS(MOD)
+CT-CT 268.       1.529        CHARMM 22 parameter file
+CF-CF 268.       1.529        wlj JPC 105, 4118 (2001)
+CT-HC 340.       1.09         CHARMM 22 parameter file
+HC-HC   0.       1.75         wlj for FEP
+DM-DM 340.       0.30         wlj
+DM-I  300.       0.30         wlj
+DM-Cl 300.       0.30         wlj
+DM-Br 300.       0.30         wlj
+DM-F  300.       0.30         wlj
+DM-HC 340.       0.30         wlj                     
+DM-HO 340.       0.10         wlj                     
+DM-HS 340.       0.10         wlj                     
+DM-H  340.       0.10         wlj
+DM-HA 340.       0.30         wlj                     
+DM-CA 367.       0.30         wlj  
+DM-NC 367.       0.30         wlj      
+DM-N  367.       0.30         wlj      
+DM-NB 367.       0.30         wlj      
+DM-NT 340.       0.30         wlj                       
+DM-N3 340.       0.30         wlj                       
+DM-CT 340.       0.30         wlj                     
+DM-SZ 340.       0.50         wlj                     
+DM-S  340.       0.50         wlj                     
+DM-OS 340.       0.30         wlj                     
+DM-OY 340.       0.30         wlj                     
+DM-OH 340.       0.30         wlj                     
+DM-ON 340.       0.10         wlj                     
+DM-O  553.       0.30         wlj                               
+DM-CM 340.       0.30         wlj
+DM-CZ 340.       0.30         wlj
+D3-D3 340.       0.30         JZV
+DM-D3 340.       0.30         JZV
+CT-N  337.       1.449
+CT-NM 337.       1.449
+CT-NC 337.       1.449        wlj azide
+CY-N$ 337.       1.449        wlj
+CT-N$ 337.       1.449        wlj
+CY-N  337.       1.449        wlj
+CT-N* 337.       1.475
+CO-N* 337.       1.475        jtr (12/7/01)
+CT-NA 337.       1.475        copy from above for CytH+ (jtr 5-14-91)
+CT-N2 337.       1.463        ARG(OL)
+CT-N3 367.       1.471        LYS(OL)
+CA-N3 400.       1.45         LYS(OL)
+CT-OH 320.       1.41
+NT-OH 320.       1.45         wlj
+NT-OS 320.       1.45         wlj
+N -OS 320.       1.45         wlj
+N -OH 400.       1.38         wlj
+CT-OS 320.       1.41
+B -OS 320.       1.486        wlj temp borate B3LYP
+OS-OS 250.       1.47         wlj
+OS-OH 250.       1.47         wlj
+OS-Cl 200.       1.69         wlj
+#####
+Si-CT 240.       1.87         wlj fit to expt
+Si-Si 125.       2.33         wlj fit to expt           
+Si-H  197.       1.485        wlj fit to expt
+Si-F  461.       1.57         wlj
+Si-Cl 223.       2.02         wlj
+Si-Br 151.       2.19         wlj
+Si-I  108.       2.44         wlj
+Si-OH 374.       1.66         wlj
+Si-OS 374.       1.66         wlj
+Si-P  108.       2.25         wlj
+Si-NT 266.       1.74         wlj
+Si-S  144.       2.15         wlj
+Si-CA 280.       1.87         wlj from MP2       
+#####
+CT-S  222.       1.81         CYX(OL)
+CY-S  222.       1.81         wlj
+CR-SA 250.       1.76         wlj
+CR-S  250.       1.76         wlj
+CW-SA 250.       1.74         wlj
+CW-S  250.       1.74         wlj
+CP-S  250.       1.74         wlj
+CP-SA 250.       1.74         wlj
+NB-S  250.       1.73         wlj
+NB-SA 250.       1.73         wlj
+N -S  250.       1.73         wlj
+CA-SH 250.       1.74         wlj
+CT-SH 222.       1.81         CYS(OL)
+CT-Cl 245.       1.781        wlj - from MM2 (Tet 31, 1971 (75))
+CA-Cl 300.       1.725        wlj
+CV-Cl 300.       1.725        wlj
+CW-Cl 300.       1.725        wlj
+CS-Cl 300.       1.725        wlj
+CU-Cl 300.       1.725        wlj
+CR-Cl 300.       1.725        wlj
+CM-Cl 300.       1.725        wlj
+C -Cl 300.       1.79         wlj
+CZ-Cl 330.       1.637        wlj
+CT-Br 245.       1.945        wlj
+CA-Br 300.       1.87         wlj
+CV-Br 300.       1.87         wlj
+CW-Br 300.       1.87         wlj
+CS-Br 300.       1.87         wlj
+CU-Br 300.       1.87         wlj
+CR-Br 300.       1.87         wlj
+CM-Br 300.       1.90         wlj
+C -Br 300.       1.98
+CZ-Br 330.       1.784        wlj
+CA-I  250.       2.08         wlj
+CV-I  250.       2.08         wlj
+CW-I  250.       2.08         wlj
+CS-I  250.       2.08         wlj
+CU-I  250.       2.08         wlj
+CR-I  250.       2.08         wlj
+CM-I  250.       2.08         wlj
+CT-I  200.       2.19         wlj see JPOC 7, 420 (1994)
+XC-Cl 600.       1.60         wlj
+XB-Br 600.       1.60         wlj for halogen bonding
+XI-I  600.       1.80         wlj Sept 2011
+CV-HA 367.       1.08
+CV-H4 367.       1.08
+CV-NB 410.       1.394        ADE,GUA,HIS
+CW-NB 410.       1.394
+CW-H4 367.       1.08
+CW-HA 367.       1.08         pyrrole - wlj
+CW-NA 427.       1.381        TRP,HIS
+CY-CY 260.       1.520        cyclopropanes, cyclobutanes - wlj
+CY-CT 280.       1.510             "
+CY-HC 340.       1.088             "
+CY-O$ 260.       1.445        oxetane MP2/6-311G(d,p) wlj 10/20
+CY-CP 280.       1.473        JT-R 2014/04 cyclopropyl thiophene
+H -N  434.       1.01         AA
+H -N3 434.       1.01
+H -N* 434.       1.01
+H -N2 434.       1.01         URA,GUA,HIS
+H -NA 434.       1.01         URA,GUA,HIS
+H2-N  434.       1.01         AA
+H2-N2 434.       1.01         ADE,GUA,CYT,GLN,ASN,ARG
+H -NT 434.       1.01
+H3-N2 434.       1.01         ADE,GUA,CYT,GLN,ASN,ARG
+H3-N3 434.       1.01         LYS(OL)
+HO-OH 553.       0.945        SUG(OL) wlj mod 0.96 -> 0.945
+""""" 460.5      0.960        Merz, JCC 15, 1019 (94)
+HO-OS 553.       0.945        SUG(OL)      6/6/94
+HS-SH 274.       1.336        CYS(OL)
+O2-P  525.       1.48          SUG(OL)
+O -P  525.       1.48
+OH-P  230.       1.61          SUG(OL)
+OS-P  230.       1.61          SUG(OL)
+CT-P  212.       1.843         wlj 11/95 MM3 based JACS 114, 8536 (92)
+CA-P  220.       1.78
+CT-P+ 212.       1.820         wlj 9/97
+S -S  166.       2.038        CYX(OL)  SCHERAGA
+C9-C9 530.       1.34           OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8 530.       1.34           OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7 530.       1.34           OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8 530.       1.34           OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7 530.       1.34           OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7 530.       1.34           OPLS hydrocarbons ff (jtr 5-14-91)
+C8-CT 317.       1.50           OPLS hydrocarbons ff (jtr 5-14-91)
+C8-CH 317.       1.50           OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C2 317.       1.50           OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C3 317.       1.50           OPLS hydrocarbons ff (jtr 5-14-91)
+C7-CT 317.       1.50           OPLS hydrocarbons ff (jtr 5-14-91)
+C7-CH 317.       1.50           OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C2 317.       1.50           OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C3 317.       1.50           OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C3 260.       1.526        Added DSM (from C3-CH)
+CT-C2 260.       1.526        Added DSM (from C2-CH)
+CA-NB 414.       1.391        Added DSM (from CB-NB)
+CA-N  427.       1.381        Added DSM (from GUA)
+CU-N  427.       1.381        wlj                     
+CW-N  427.       1.381        wlj                      
+CM-N  427.       1.381        wlj                      
+CB-CT 317.       1.51         Added DSM (from CA-CT)
+CC-CB 520.       1.370        Added DSM (from CB-CB)
+CT-F  367.       1.36         wlj compromise JPCA 7202 (2006)
+CF-F  367.       1.332        wlj JPCA 105, 4118 (2001)      
+***** 367.       1.332        PAK CT-F for CHF3 (emd 5-09-94)
+C2-F  367.       1.38         wlj
+CA-F  420.       1.354        wlj
+CU-F  420.       1.354        wlj
+CW-F  420.       1.354        wlj
+CS-F  420.       1.354        wlj
+CV-F  420.       1.354        wlj
+CR-F  420.       1.354        wlj
+CM-F  420.       1.340        wlj
+CZ-F  450.       1.279        wlj
+C -F  420.       1.357        wlj
+CT-CO 268.       1.5290       =CT-CT - wd 3/95
+OH-CO 320.       1.38         =CO-OS - wd 3/96
+HC-CO 340.       1.09         =CT-HC - wd 3/95
+SY-C3 222.       1.81
+SY-CA 340.       1.77
+SY-CM 340.       1.79
+SY-C8 222.       1.76
+SY-OY 700.       1.44
+SZ-OY 700.       1.53
+SY-N  434.       1.67
+SY-OH 450.       1.67 
+SY-OS 450.       1.67 
+SY-F  450.       1.60 
+SY-CT 340.       1.77
+SZ-CT 340.       1.79
+U -OU 500.       1.80           J Phys Chem 97, 5685 (1993)
+CZ-S  300.       1.685          wlj 9/06
+CA-S  250.       1.76           thioanisole             copy from CW-S          rcr HIVRT
+CM-S  250.       1.76           hept,                   copy from CW-S          rcr HIVRT
+CM-CY 317.       1.51           hept,                   copy from CM-CT         rcr HIVRT
+CY-NT 382.       1.448          nev,                    copy from CT-NT         rcr HIVRT
+SY-NT 340.       1.77           nev,                    copy from SY-CT         rcr HIVRT
+C -NT 317.       1.522          nev,                    copy from C -CT         rcr HIVRT
+C -CW 400.       1.490          bhap,                   copy from C -CA         rcr HIVRT
+Zn-N   40.       2.05           Merz, JACS 113, 8262 (1991)
+Zn-OH  94.       1.80             "
+Zn-OW  40.       2.05             "
+CP-SA 250.       1.71           MKD New Thiophene -MP2(full)/6-311G(d,p), JT-R 2014/04 change "S " to SA   
+CP-CS 546.       1.38           MKD New Thiophene -MP2(full)/6-311G(d,p)
+CP-HA 367.       1.08           MKD New Thiophene -MP2(full)/6-311G(d,p)
+CP-C! 385.       1.46           MKD New Thiophene -MP2(full)/6-311G(d,p) 
+C!-C= 385.       1.38           MKD MP2(full)/6-311G(d,p)
+NX-CW 427.       1.38           MKD synonym for NA-CW
+NX-C! 385.       1.44           MKD synonym for NA-C!
+NX-NB 400.       1.35           MKD synonym for NA-NB
+NE-C  418.       1.388          MKD NE is synonym for NA in 5-membered rings such as hydantoin
+CT-NE 337.       1.475
+C!-NE 385.       1.42
+NE-H  434.       1.01
+NS-CT 337.       1.475          MKD synonym for CT-NA
+NS-CW 427.       1.381          MKD synonym for CW-NA
+CT-CU 317.       1.49           MKD MP2(full)/6-311G(d,p) - 3-methyl-isoxazole
+
+********                        line above must be blank
+HW-OW-HW    75.00      109.50   For TIP4F Water - wlj 1/98
+HW-OW-LP    50.00       54.75   For TIP4F Water - wlj 1/98
+********    34.05      104.52   J Phys Chem 91, 3349 (1987) -For TIP3F Water (HW-OW-HW)
+LP-NC-CA   150.0       120.0    wlj 7/14
+LP-NC-CB   150.0       120.0
+LP-NC-CQ   150.0       120.0
+LP-NC-CM   150.0       120.0
+LP-NC-CZ   150.0       120.0
+LP-NC-CT   150.0       120.0
+LP-NC-C:   150.0       120.0
+LP-NC-C=   150.0       120.0
+LP-NC-C!   150.0       120.0
+LP-NC-NC   150.0       120.0
+LP-NC-H    150.0       120.0
+LP-NC-OH   150.0       120.0
+LP-NC-OS   150.0       120.0
+LP-NC-OS   150.0       120.0
+LP-NC-S    150.0       120.0
+LP-NB-NS   150.0       128.0
+LP-NB-NX   150.0       128.0
+LP-NB-NH   150.0       128.0
+LP-NB-CU   150.0       128.0
+LP-NB-CR   150.0       128.0
+LP-NB-CV   150.0       128.0
+LP-NB-CP   150.0       128.0
+LP-NB-OA   150.0       128.0
+LP-NB-SA   150.0       128.0
+LP-OA-CW   150.0       126.0
+LP-OA-CR   150.0       126.0
+LP-OA-CB   150.0       126.0
+LP-OA-NB   150.0       126.0
+LP-SA-CP   150.0       134.0
+LP-SA-CR   150.0       134.0
+LP-SA-CB   150.0       134.0
+LP-SA-NB   150.0       134.0
+LP-N=-CM   150.0       120.0
+LP-N=-C=   150.0       120.0
+LP-N=-CA   150.0       120.0
+LP-N=-C!   150.0       120.0
+LP-N=-N=   150.0       120.0
+LP-NZ-CZ   150.0       180.0
+********
+OU-U -OU   150.0       180.0    J Phys Chem 97, 5685 (1993)
+CA-Cl-XC   200.        180.0    wlj 9/11
+CA-Br-XB   200.        180.0    wlj 9/11 halogen bonding
+CA-I -XI   200.        180.0    wlj 9/11
+CT-Cl-XC   200.        180.0    wlj 9/11
+CT-Br-XB   200.        180.0    wlj 9/11 halogen bonding
+CT-I -XI   200.        180.0    wlj 9/11
+CM-Cl-XC   200.        180.0    wlj 9/11
+CM-Br-XB   200.        180.0    wlj 9/11 halogen bonding
+CM-I -XI   200.        180.0    wlj 9/11
+HC-C*-CW    35.        126.8
+HC-C*-CB    35.        126.8
+HC-CS-CW    35.        126.8
+HC-CS-CB    35.        126.8
+HA-CA-CW    35.        126.9    wlj - pyrrole
+HC-C=-CW    35.        122.0    wlj
+HA-CW-CA    35.        130.7    wlj
+HA-CW-C=    35.        130.7    wlj
+HA-CW-NA    35.        121.6    wlj
+CT-CW-NA    70.        121.6    wlj
+C!-CW-NA    70.        121.6    wlj
+CT-CW-OA    70.        116.6    JT-R 2014/04 MP2/aug-cc-pVTZ - changed from 12.16 wlj
+CY-CW-OA    70.        116.6    JT-R 2014/04 MP2/aug-cc-pVTZ - changed from 12.16 wlj
+########                        C!-CW-OS    70.        121.6    wlj
+C!-CW-OS    70.        117.3    MKD MP2(full)/6-311G(d,p) changed from 121.6
+CA-CW-NA    70.        121.6    wlj
+HA-CW-CV    35.        132.0    wlj - imidazole & triazole
+HA-CV-CW    35.        128.2    wlj
+CM-C:-CM   160.        180.     wlj 9/06
+CM-C:-O    160.        180.     wlj 9/06
+O -C:-O    160.        180.     wlj 1/23 fro CO2 - check
+C:-CM-HC    40.        121.0    wlj 9/06
+C:-CM-CT    80.        122.0    wlj 9/06
+C:-CM-CA    80.        122.0    wlj 9/06
+C:-CM-F     80.        125.0    wlj 9/06
+HC-CT-CZ    35.        108.5    wlj
+CT-CT-CZ    58.35      112.7    wlj
+CT-CZ-CZ   150.        180.     do 11/98 - JPOC, 9, 191(1996)
+CA-CZ-CZ   160.        180.     wlj
+CM-CZ-CZ   160.        180.     wlj
+C=-CZ-CZ   160.        180.     wlj
+C -CZ-CZ   160.        180.     wlj
+S -CZ-CZ   140.        180.     wlj 9/06
+HC-CZ-CZ   112.        180.     do 1/99  - JPOC, 9, 191(1996)
+CA-CA-CZ    70.        120.     wlj
+CT-CZ-NZ   150.        180.     wlj
+N2-CZ-NZ   150.        180.     wlj
+CA-CZ-NZ   150.        180.     wlj
+CU-CZ-NZ   150.        180.     wlj
+CM-CZ-NZ   150.        180.     wlj
+C -CZ-NZ   150.        180.     wlj
+C=-CZ-NZ   150.        180.     wlj
+HC-CT-NZ    35.        108.5    wlj  10/04 isonitrile
+CA-CA-NZ    80.        120.     wlj  10/04   " 
+CT-NZ-CZ   150.        180.     wlj  10/04   "
+CA-NZ-CZ   170.        180.     wlj  10/04   "
+CT-CX-NA    70.        121.6    jtr - copy from CT-CW-NA for HIP
+HA-CX-CX    35.        130.7    jtr - copy from HA-CW-CV for HIP
+CX-CX-NA     70.       106.3    jtr - copy from CV-CW-NA for HIP
+CX-NA-CR     70.       109.8    jtr - copy from CW-NA-CR for HIP
+C2-C -N     70.        116.6    GLY             GELIN
+C2-C -O     80.        120.4    ASN(OL)         GELIN
+C2-C -O2    70.        117.    GLU(OL)          SCH JPC 79,2379
+C3-C -N     70.        116.6     ACET(OL)        BENEDETTI
+C3-C -O     80.        120.4     ACET(OL)
+C3-C -O2    70.        117.    GLU(OL)          SCH JPC 79,2379
+CA-C -CA    85.        120.     TYR(OL)         GELIN
+CA-C -OH    70.        120.     TYR(OL)        GELIN
+CA-CA-OH    70.        120.
+NC-CA-OH    70.        120.     wlj
+CA-CA-SH    70.        120.     wlj
+C!-N -S     70.        117.     wlj
+C -N -S     70.        112.     wlj
+CA-CA-OS    70.        120.     wlj
+CM-CM-OS    70.        123.     wlj
+C=-CM-OS    70.        123.     wlj
+CM-CM-OH    70.        123.     wlj
+C=-CM-OH    70.        123.     wlj
+CB-C -NA    70.        111.3    GUA
+CV-C -NA    70.        111.3    GUA
+CB-CV-NA    70.        111.3    GUA
+CB-C -O     80.        125.0    GUA           wlj changed from 128.8 5/17
+CV-C -O     80.        125.0    GUA
+CB-C -N     70.        111.3    wlj
+CS-C -O     80.        128.2    wlj
+CD-C -CD    85.        120.     TYR(OL)         GELIN
+CD-C -OH    70.        120.     TYR(OL)        GELIN
+CH-C -N     70.        116.6    AA(OL)
+CH-C -O     80.        120.4    AA(OL)
+CH-C -O2    65.        117.     AA(OL)          SCH JPC 79,2379
+CH-C -OH    70.        115.     ACID(OL)        SCH JPC 79,2379
+CJ-C -NA    70.        114.1    URA
+CJ-C -O     80.        125.3    URA
+CM-C -NA    70.        114.1    THY
+CM-C -O     80.        125.3    THY
+CZ-C -O     80.        123.0       
+C=-C -O     80.        124.     wlj
+C=-C -HC    80.        116.     wlj
+CT-C -N     70.        116.6
+CT-C -NM    70.        116.6
+CA-C -N     70.        115.5   wlj 8/97 benzamide
+CM-C -N     70.        115.5   wlj
+CT-C -O     80.        120.4
+CA-C -O     80.        120.4   wlj
+CT-C -S=    70.        123.0   wlj mod 9/08
+CT-NO-ON    80.        117.5   wlj  nitro
+CA-NO-ON    80.        117.5   wlj  nitro
+CT-CT-NO    63.        111.1   wlj  nitro
+HC-CT-NO    35.        105.0   wlj  nitro
+CA-CA-NO    85.        120.0   wlj  nitro
+HC-C -N     40.        114.      wlj  
+HC-C -OS    40.        115.       "
+HC-C -OH    40.        115.       "
+O -C -HC    35.        123.0      wlj
+S=-C -HC    35.        127.0      wlj
+NC-C -HC    35.        122.0      wlj
+CT-C -OH    70.        108.    RCOOH  wlj 2/15/95
+CT-C -CT    70.        116.    wlj 7/96
+CT-C -CA    70.        116.    wlj
+C=-C -CT    70.        116.    wlj
+CT-C -O2    70.        117.    GLU(OL)     SCH JPC 79,2379
+CA-C -O2    70.        117.    GLU(OL)     SCH JPC 79,2379
+CT-CT-Cl    69.        109.8               wlj - from MM2
+C -CT-Cl    69.        109.8               wlj
+CA-CA-Cl    75.        120.0               wlj
+CM-CM-Cl    75.        121.5               wlj
+Cl-CM-HC    60.        114.0               wlj
+Cl-CT-Cl    78.        111.7               " Tet 31, 1971 (75)
+HC-CT-Cl    51.        107.6               " see also JACS 121,9198
+CT-CT-Br    69.        110.0               wlj           
+CA-CT-Br    69.        110.0               wlj           
+C -CT-Br    69.        109.8               wlj
+CT-C -Cl    75.        109.0               wlj
+CT-C -Br    75.        109.0               wlj
+O -C -Cl    75.        119.0               wlj
+O -C -Br    75.        119.0               wlj
+CA-CA-Br    75.        120.0               wlj
+CM-CM-Br    75.        120.0               wlj
+Br-CM-HC    60.        114.0               wlj
+Br-CT-Br    78.        111.7               wlj
+HC-CT-Br    51.        107.6               wlj
+CA-CA-I     75.        120.0               wlj
+CT-CT-I     75.        112.0               wlj
+HC-CT-I     75.        111.0               wlj
+CA-CA-F     80.        120.0    wlj
+CM-CM-F     80.        121.5    wlj
+C -CM-F     80.        121.5    wlj
+F -CM-HC    50.        112.0    wlj
+F -CM-F     80.        108.0    wlj
+F -C -O     80.        121.0    wlj
+F -C -CT    80.        111.0    wlj
+N -C -O     80.        122.9    AA(OL)
+NM-C -O     80.        122.9    
+N -C -N     70.        114.2    copy from above for Urea (jtr 5-14-91)
+N -C -S=    70.        127.0    wlj mod 9/08
+N*-C -NA    70.        115.4    URA
+N*-C -NC    70.        118.6    CYT
+NA-C -NA    70.        118.6    copy from above for CytH+ (jtr 5-14-91)
+N*-C -O     80.        120.9    URA,CYT
+NA-C -O     80.        120.6    URA(2),GUA
+NC-C -O     80.        122.5    CYT
+NC-C -NA    70.        118.6
+NA-CM-H4    35.        119.1
+N*-CM-H4    35.        119.1    jtr 12/11/01
+N -CA-HA    35.        119.1    wlj
+O -C -O     80.        126.0     COO- terminal residues
+ON-NO-ON    80.        125.0    wlj  nitro
+ON-N -ON    80.        120.0    wlj  nitrate anion
+O -C -OH    80.        121.0    RCOOH  wlj 2/15/95
+O2-C -O2    80.        126.0     GLU(OL)      SCH JPC 79,2379
+C2-C*-CB    70.        128.6       TRP(OL)
+C2-CA-CB    70.        128.6       TRP(OL)
+C2-C*-CG    70.        125.       TRP(OL)
+C2-C*-CC    70.        125.       TRP(OL)
+C2-C*-CW    70.        125.       TRP(OL)
+CB-C*-CG    85.        106.4       TRP(OL)
+CB-C*-CT    70.        128.6       TRP(OL)
+CB-C*-CW    85.        106.4       TRP(OL)
+CT-C*-CW    70.        125.       TRP(OL)
+C2-CS-CG    70.        125.      
+C2-CS-CC    70.        125.     
+C2-CS-CW    70.        125.    
+CB-CS-CG    85.        106.4    
+CB-CS-CT    70.        128.6   
+CB-CS-CW    85.        106.4  
+CT-CS-CW    70.        125.               
+C -C2-C2    63.0       112.4      GLU
+C -C2-CH    63.0       112.4      ASP
+C -C2-N     80.0       110.3      GLY   WORK DONE ON 6/23/82
+C -C2-NT    80.0       111.2       GLY   JCP 76, 1439
+C*-C2-CH    63.0       115.6      TRP(OL)
+C2-C2-C2    63.0       112.4       PRO,LYS
+C2-C2-C3    63.0       112.4       alkanes
+C3-C2-C3    63.0       112.4       alkanes
+C2-CH-C3    63.0       112.4       alkanes
+C2-CH-C2    63.0       112.4       alkanes
+C2-C2-CH    63.0       112.4       MET
+C2-CH-OH    80.0       109.5       alcohols
+C3-C2-OH    80.0       109.5       alcohols
+C2-C2-OH    80.0       109.5       alcohols
+C2-C2-N     80.0       111.2       PRO   JCP 76, 1439
+C2-C2-N2    80.0       111.2      ARG   JCP 76, 1439
+C2-C2-N3    80.0       111.2      LYS(OL)   JCP 76, 1439
+**C2-C2-NT    80.0       111.2       PRO   JCP 76, 1439
+CT-CT-NT    56.2       109.47      wlj - MM3 based - JACS 112, 8314 (90)
+C3-CT-NT    56.2       109.47      wlj - MM3 based - JACS 112, 8314 (90)
+C2-CT-NT    56.2       109.47      wlj - MM3 based - JACS 112, 8314 (90)
+CH-CT-NT    56.2       109.47      wlj - MM3 based - JACS 112, 8314 (90)
+CT-C2-NT    56.2       109.47      wlj - MM3 based - JACS 112, 8314 (90)
+C3-C2-NT    56.2       109.47      wlj - MM3 based - JACS 112, 8314 (90)
+C2-C2-NT    56.2       109.47      wlj - MM3 based - JACS 112, 8314 (90)
+CH-C2-NT    56.2       109.47      wlj - MM3 based - JACS 112, 8314 (90)
+CT-CH-NT    56.2       109.47      wlj - MM3 based - JACS 112, 8314 (90)
+C3-CH-NT    56.2       109.47      wlj - MM3 based - JACS 112, 8314 (90)
+C2-CH-NT    56.2       109.47      wlj - MM3 based - JACS 112, 8314 (90)
+CH-CH-NT    56.2       109.47      wlj - MM3 based - JACS 112, 8314 (90)
+C2-C2-OS    80.0       109.5      THF fit
+C3-CH-OS    80.0       109.5      wlj - guess
+C2-C2-S     50.        114.7      MET            SCHERAGA  JPC 79,1428
+C3-C2-CH    63.0       112.4      ILE
+C3-C2-OS    80.0       109.5       MEE
+CA-C2-CH    63.        114.       PHE(OL)         SCH JPC  79,2379
+CD-C2-CH    63.        114.       PHE(OL)         SCH JPC  79,2379
+CC-C2-CH    63.0       113.1      HIS(OL)
+CH-C2-CH    63.0       112.4      SUG,LEU
+CH-C2-OH    80.0       109.5      SER,end sugar
+CH-C2-OS    80.0       109.5      SUG
+CH-C2-S     50.        114.7      CYX            SCHERAGA  JPC 79,1428
+CH-C2-SH    50.0       108.6      CYS
+C3-C2-CT    63.0       112.4    from C3-C2-CH ILE, alkanes for SKF8
+C2-C2-CA    63.0       112.4    from C2-C2-C3 alkanes for SKF8
+CH-CA-CA    70.        120.     from C2-CA-CA PHE(OL) for SKF8
+C2-CH-CA    63.0       112.4    from C2-CH-C3 alkanes for SKF8
+C -CA-CA    85.        120.     TYR(OL)
+C -CA-HA     35.       120.0
+C2-CA-CA    70.        120.     PHE(OL)
+C2-CA-CD    70.        120.     PHE(OL)
+C2-CD-CD    70.        120.     PHE(OL)
+CA-CA-CA    63.        120.     PHE(OL)
+CB-CB-CB    63.        120.     wlj    
+CB-CA-CB    63.        120.     wlj      
+CA-C!-CA    63.        120.     wlj
+CA-C!-CB    63.        120.     wlj
+CA-C!-C!    63.        120.     wlj
+CB-C!-C!    63.        120.     wlj
+CA-CA-C!    63.        120.     wlj
+C!-CA-C!    63.        120.     wlj
+CA-C!-CR    63.        120.     wlj
+CA-C!-CS    63.        120.     wlj
+CA-C!-CW    63.        120.     wlj
+CA-C!-CU    63.        120.     wlj
+CA-C!-CV    63.        120.     wlj
+CA-CA-CB    63.        120.     wlj
+CA-CA-CN    85.        120.     TRP(OL)
+CA-CA-CM    70.        124.     wlj/mp
+CA-CA-C=    70.        124.     wlj
+CA-CA-C#    70.        124.     wlj/mp
+CA-CM-CT    85.        119.7    wlj/mp
+CA-CA-CT    70.        120.     PHE(OL)
+CA-CA-NT    70.        120.     wlj/rr anilines
+CA-CA-N3    70.        120.     wlj    anilinium
+CA-CA-HA     35.       120. 
+C!-CA-HA     35.       120.     wlj
+CA-CA-DM    10.0        90.     dummy
+HA-CA-DM     2.0        90.     dummy
+CA-NC-DM     5.0       120.0    wlj 8/07
+C!-NC-DM     5.0       120.0    wlj 8/07
+OY-SZ-DM    10.0        90.     dummy
+CT-NC-NZ     70.       120.0    wlj azide
+NC-NZ-NZ    100.       180.0    wlj azide
+CS-NZ-NZ    100.       180.0    wlj diazo
+CM-NZ-NZ    100.       180.0    wlj diazo
+C -NZ-NZ    100.       180.0    wlj diazo
+CT-CT-NC     65.       109.0    wlj azide
+NC-C -HC     35.       116.0    wlj imine - check          
+N=-C -HC     35.       116.0    wlj imine - check          
+CV-CA-NC     70.       120.0    wlj 6/14 ai               
+CV-CB-NC     70.       126.0    wlj 6/14 ai purine        
+CB-CV-NB     70.       111.0    wlj 6/14 ai               
+CV-CA-N      70.       122.0    wlj 6/14 ai               
+CA-CV-CB     70.       116.0    wlj 6/14 ai               
+NC-CA-N      70.       118.0    wlj 6/14 ai               
+NC-CM-N      70.       118.0    wlj 6/14 ai               
+NC-CA-HA     35.       116.0    wlj 12/96 based on pyridine
+CA-CA-NC     70.       124.0    wlj   "     "    "     "
+CA-C!-NC     70.       124.0    wlj   "     "    "     "
+C!-CA-NC     70.       124.0    wlj   "     "    "     "
+C -CA-NC     70.       120.0    wlj                     
+C -CB-NC     70.       120.0    wlj                     
+NC-CA-S      70.       117.0    JT-R 2014/04 thiomethyl pyridine MP2/aug-cc-pVTZ
+NC-CA-SH     70.       117.0    JT-R 2014/04 thiol pyridine MP2/aug-cc-pVTZ
+NA-CW-S      65.       122.0    JT-R 2014/04 thiomethyl pyrrole MP2/aug-cc-pVTZ
+NA-CW-SH     65.       122.0    JT-R 2014/04 thiol pyrrole MP2/aug-cc-pVTZ
+NA-CW-OH     65.       122.0    JT-R 2014/04 hydroxy pyrrole MP2/aug-cc-pVTZ
+NA-CW-OS     60.       120.0    JT-R 2014/04 methoxy pyrrole MP2/aug-cc-pVTZ
+CS-CW-NT     60.       130.5    JT-R 2014/04 amino pyrrole MP2/aug-cc-pVTZ
+NA-CW-NT     60.       121.5    JT-R 2014/04 amino pyrrole MP2/aug-cc-pVTZ
+SA-CP-OS     60.       120.3    JT-R 2014/04 methoxy thiophene MP2/aug-cc-pVTZ
+CS-CP-OS     60.       128.0    JT-R 2014/04 methoxy thiophene MP2/aug-cc-pVTZ
+CP-OS-CT     60.       114.0    JT-R 2014/04 methoxy thiophene MP2/aug-cc-pVTZ
+SA-CP-SH     65.       121.6    JT-R 2014/04 thiophene thiol MP2/aug-cc-pVTZ
+CS-CP-SH     65.       127.1    JT-R 2014/04 thiophene thiol MP2/aug-cc-pVTZ
+CP-SH-HS     60.        96.0    JT-R 2014/04 thiophene thiol MP2/aug-cc-pVTZ
+SA-CP-S      65.       121.6    JT-R 2014/04 thiophene thioethers MP2/aug-cc-pVTZ
+CS-CP-S      65.       127.1    JT-R 2014/04 thiophene thioethers MP2/aug-cc-pVTZ
+CP-S -CT     60.        99.9    JT-R 2014/04 thiophene thioethers MP2/aug-cc-pVTZ
+C!-C!-NC     70.       120.0    wlj  11/28/17            
+********                        C!-C!-NC     70.       116.8    MKD MP2(full)/6-311G(d,p) changed from 124
+CA-NC-CA     70.       117.0    wlj   "     "    "     "
+CA-NC-C!     70.       117.0    wlj   "     "    "     "
+CB-NC-C!     70.       117.0    wlj   "     "    "     "
+CA-N -CA     70.       118.0    wlj   pyridine N-oxide  
+CA-N -ON     70.       121.0    wlj   "     "    "     " 
+CA-N -CW     70.       118.0    wlj                     
+CA-N -CS     70.       118.0    wlj                     
+CA-N -CU     70.       118.0    wlj                     
+CT-NC-ON     70.       114.0    wlj   nitroso            
+CA-CA-CW     70.       107.4    wlj  1/97 based on pyrrole
+CW-NA-CW     70.       109.8    wlj   "     "    "     "
+CB-NA-CW     70.       109.8    wlj   "     "    "     "
+CV-CW-NA     70.       106.3    wlj   "     "  imidazole
+CW-CV-NB     70.       111.0    wlj   "     "    "
+CW-NA-CR     70.       109.8    wlj   "     "    "
+CW-CV-NB     70.       108.7    wlj  6/13         
+CV-CW-NA     70.       103.6    wlj  6/13               
+CB-NA-CR     70.       109.8    wlj
+CW-C=-C=     35.       106.0    wlj
+CA-NA-CK     70.       109.8    wlj
+NC-CA-CT     70.       116.0    wlj
+NC-CA-CY     70.       116.0    copy of above for cpr-pyridine JT-R 2014/04
+NC-CQ-CT     70.       115.5    wlj
+NB-CV-CT     70.       124.5    wlj
+CA-CV-NB     70.       111.0    wlj
+CA-NC-NC     70.       117.0    wlj  pyridazine
+CT-NC-NC     70.       117.0    wlj  azo
+########                        OS-CW-CS     70.       110.6    wlj  
+OS-CW-CS     60.       130.0    JT-R 2014/04 methoxy pyrrole MP2/aug-cc-pVTZ was using 70,110.6 wlj
+OS-CB-CB     70.       110.6    wlj  
+OS-CW-C=     70.       110.0    wlj  furan
+OA-CW-CS     70.       109.8    JT-R 2014/04 furan MP2/aug-cc-pVTZ was using 70,110.6 wlj
+CW-OA-CW     70.       107.4    JT-R 2014/04 furan MP2/aug-cc-pVTZ was 70,106.5 wlj
+CW-OS-CB     70.       106.5    wlj  furan
+CR-OS-CB     70.       106.5    wlj  furan
+OA-CW-HA     35.       113.4    wlj  furan
+OA-CW-CM     60.       117.1    JT-R 2014/04 furan MP2/aug-cc-pVTZ
+OA-CW-C=     60.       117.1    JT-R 2014/04 furan MP2/aug-cc-pVTZ
+OA-CW-OH     60.       115.0    JT-R 2014/04 furan MP2/aug-cc-pVTZ
+OA-CW-OS     60.       115.9    JT-R 2014/04 furan MP2/aug-cc-pVTZ
+OA-CW-SH     60.       116.3    JT-R 2014/04 furan MP2/aug-cc-pVTZ
+OA-CW-S      60.       116.8    JT-R 2014/04 furan MP2/aug-cc-pVTZ
+OA-CW-NT     60.       116.8    JT-R 2014/04 furan MP2/aug-cc-pVTZ
+S -CW-HA     35.       125.0    wlj 12/07
+SA-CR-HA     35.       125.0    wlj 12/07
+SA-CW-CT     70.       125.0    wlj 1/09 
+SA-CP-CT     70.       121.4    JT-R 2014/04 thiophenes MP2/aug-cc-pVTZ
+SA-CP-CM     70.       121.4    JT-R 2014/04 thiophenes MP2/aug-cc-pVTZ
+SA-CP-C=     70.       121.4    JT-R 2014/04 thiophenes MP2/aug-cc-pVTZ
+SA-CP-OH     70.       120.3    JT-R 2014/04 thiophenes MP2/aug-cc-pVTZ
+CS-CP-CM     70.       128.5    JT-R 2014/04 thiophenes MP2/aug-cc-pVTZ
+CS-CP-C=     70.       128.5    JT-R 2014/04 thiophenes MP2/aug-cc-pVTZ
+S -CR-CT     70.       125.0    wlj 1/09 
+S -CW-N      70.       125.0    wlj 12/07
+S -CR-N      70.       125.0    wlj 12/07
+S -CR-NT     70.       120.2    wlj
+NB-CR-NT     70.       126.1    wlj
+S -CW-CV     70.       111.0    wlj
+S -CW-CS     65.       130.0    JT-R 2014/04 thiomethyl pyrrole MP2/aug-cc-pVTZ was 70,111.0 wlj
+SH-CW-CS     65.       130.0    JT-R 2014/04 thiol pyrrole MP2/aug-cc-pVTZ was using 70,120.0 wlj
+OH-CW-CS     65.       130.0    JT-R 2014/04 hydroxy pyrrole MP2/aug-cc-pVTZ was using 70,120.0 wlj
+OH-CP-CS     65.       127.7    JT-R 2014/04 hydroxy thiophene MP2/aug-cc-pVTZ was using 70,120.0 wlj
+S -CB-CB     70.       111.0    wlj
+NA-CB-CS     70.       107.7    wlj/ah
+NA-CW-CS     70.       107.7    wlj/nm
+CW-CS-CS     70.       107.3     "
+CB-CS-CS     70.       107.3     "
+CB-CB-CS     70.       107.3     "
+CW-CS-HA     35.       125.7     "
+CW-CS-C!     70.       125.7     "
+CW-CV-C!     70.       125.7     "
+CS-CW-C!     70.       132.1     "
+CS-CS-C!     70.       127.5     "
+CS-CW-HA     35.       132.1     "
+CS-CW-CT     70.       134.0    JT-R 2014/04
+CS-CP-CT     70.       128.5    JT-R 2014/04
+CS-CW-CA     70.       132.1    wlj/nm    
+CS-CS-HA     35.       127.5     "
+CU-NB-NA     70.       104.1     "
+CW-NB-NA     70.       104.1     "
+NB-CU-HA     35.       118.9     "
+NB-CU-CT     70.       118.9     "
+NB-CW-CT     70.       118.9     "
+NB-CU-CZ     70.       118.9      
+CU-CS-CW     70.       103.8     "
+CW-CS-CW     70.       103.8     "
+NB-CU-CS     70.       111.9     "
+NB-CW-CS     70.       111.9     "
+CA-CU-HA     35.       128.6     "
+CU-CA-HA     35.       128.2     "
+CU-NB-OS     70.       105.3     "
+NB-NA-CW     56.       113.1     "
+CB-NA-NB     56.       113.1     "
+CR-NA-NB     56.       113.1     "
+NB-NA-H      56.       119.3     " wlj 6/13
+NB-NA-CA     70.       118.4     "
+NB-NA-CT     70.       118.4     "
+CW-OA-NB     70.       108.9     "
+C -N -OS     70.       108.6     "
+N -OS-CB     70.       104.5     "
+NB-OA-CR     70.       101.3       JT-R oxatriazoles
+NB-CR-OA     70.       115.0       JT-R oxatriazoles
+CR-NB-OA     70.       107.3       JT-R oxatriazoles
+NB-CR-SA     70.       115.0     "
+CR-OS-CW     70.       104.0     "
+CV-CW-OA     70.       108.0     "
+CV-CW-OS     70.       108.0     "
+HA-CR-OA     35.       117.0     "
+OS-CM-HC     35.       114.5
+CB-CA-HA     35.       120.0
+CB-CA-N2    70.        123.5    ADE
+CB-CA-NC    70.        117.3    ADE
+CD-CA-CD    85.        120.     PHE(OL)
+CJ-CA-N2    70.        120.1    CYT
+CJ-CA-NC    70.        121.5    CYT
+CM-CA-N2    70.        120.1
+CM-C=-N     70.        120.1
+CA-CA-N2    70.        120.1    wlj
+CM-CA-NC    70.        121.5
+CM-C=-NC    70.        121.5
+C=-CA-NC    70.        121.5
+CM-CA-NA    70.        121.5    copy from above for CytH+ (jtr 5-14-91)
+CN-CA-HA     35.       120.0
+NY-CA-NY    70.        111.8    jtr: neutral ARG
+NC-CA-NY    70.        124.1    jtr: neutral ARG
+CA-NC-H     35.        113.0    jtr: neutral ARG
+CA-NY-H     50.        112.5    jtr: neutral ARG
+CA-NY-CT    50.        120.5    jtr: neutral ARG
+H -NY-H     43.6       106.4    jtr: neutral ARG
+CT-NY-H     35.        109.5    jtr: neutral ARG
+CT-CT-NY    80.0       111.2    jtr: neutral ARG
+HC-CT-NY     35.       109.5    jtr: neutral ARG
+N2-CA-N2    70.        120.       ARG(OL)
+N2-CA-NA    70.        116.0    GUA
+N2-CA-NC    70.        119.3    ADE,GUA
+N2-CQ-NC    70.        119.3    wlj    
+N2-CQ-N     70.        116.0    wlj
+NA-CA-NC    70.        123.3    GUA
+NA-CM-NC    70.        123.3    GUA
+C -CB-CB    85.        119.2    GUA
+C -CV-CB    85.        119.2    wlj
+C -CB-NB    70.        130.     GUA
+C -CV-NB    70.        130.     GUA
+N -CQ-NC    70.        123.3    wlj
+C -CS-CW    70.        130.     wlj
+C -CB-CW    70.        130.     wlj
+CA-CB-CA    85.        134.9     TRP(OL)
+CS-CB-CA    85.        134.9     
+CS-CB-CD    85.        134.9     
+CS-CB-CN    85.        108.8     
+CA-CB-CB    85.        117.3    ADE
+C!-CB-CB    85.        117.3    ADE
+CA-CB-CN    85.        116.2     TRP
+CA-CB-NB    70.        132.4    ADE
+CB-CB-N*    70.        106.2    GUA,ADE
+CB-CB-NA    70.        106.2    wlj
+CV-CB-NA    70.        106.2    wlj
+CS-CR-NA    70.        106.2    wlj
+CB-CB-NB    70.        111.0    GUA,ADE
+CR-CS-CW    70.        110.4    wlj
+CB-CB-NC    70.        127.7    GUA,ADE
+CA-CB-NC    70.        118.4    wlj 7/14
+CB-CB-N     70.        127.7    wlj
+CS-CR-NC    70.        127.7    wlj
+CD-CB-CN    85.        116.2     TRP
+N*-CB-NC    70.        126.2    GUA,ADE
+NA-CB-NC    70.        126.2    wlj
+NB-CB-N     70.        126.2    wlj
+NB-CR-N     70.        126.2    wlj
+NA-CR-NC    70.        126.2    wlj
+C!-CR-OS    70.        122.0    wlj 12/06
+########                        C!-CR-NB    70.        130.0    wlj 12/06
+C!-CR-NB    70.        125.2    MKD MP2(full)/6-311G(d,p) changed from 130.0
+CR-NB-NB    70.        109.0    wlj 12/06
+CV-NB-NB    70.        109.3    wlj 6/13 
+CV-NB-OA    70.        110.3    wlj 6/13 
+CV-NB-SA    70.        113.3    JT-R thiadiazoles
+CR-OA-CR    70.        107.0    wlj 12/06
+CW-CW-NA    70.        120.0
+C -CD-CD    85.        120.     TYR(OL)
+CA-CD-CD    85.        120.     PHE
+CB-CD-CD    85.        120.      TRP(OL)
+CD-CD-CD    85.        120.     PHE(OL)
+CD-CD-CN    85.        120.     TRP(OL)
+N*-CE-NB    70.        113.9    ADE,GUA
+CA-CA-NA    70.        108.7     TRP(OL)
+C -CH-C2    63.0       111.1      AA
+C -CH-C3    63.0       111.1      ALA
+C -CH-CH    63.0       111.1      ILE
+C -CH-N     63.0       110.1      AA     WORK DONE ON 6/23/82
+C -CH-NT    80.0       109.7      AA
+C2-CH-CH    63.0       111.5      SUG,ILE
+C2-CH-N     80.0       109.7      ALA    JACS 94, 2657
+C2-CH-N*    80.0       109.5      SUG
+C2-CH-OS    80.0       109.5      SUG
+C3-CH-C3    63.0       111.5      VAL
+C3-CH-CH    63.0       111.5      ILE
+C3-CH-N     80.        109.5                 **
+C3-CH-OH    80.0       109.5      THR
+CH-CH-CH    63.0       111.5      SUG
+CH-CH-N     80.0       109.7      ILE    JACS 94, 2657
+CH-CH-N*    80.0       109.5      SUG
+CH-CH-OH    80.0       109.5      THR,end sugar
+CH-CH-OS    80.0       109.5      SUG
+N*-CH-OS    80.0       109.5      SUG
+NC-CI-NC    70.        129.1    ADE
+C -CJ-CJ    85.        120.7    URA
+CA-CJ-CJ    85.        117.0    CYT
+CJ-CJ-N*    70.        121.2    CYT
+CM-CJ-N*    70.        121.2    THY
+N*-CK-NB    70.        113.9
+NA-CK-NB    70.        113.9      wlj
+NA-CK-H5    35.        123.05
+N*-CK-H5    35.        123.05
+NB-CK-H5    35.        123.05
+C -CM-C3    85.        119.7      THY
+C -CM-CJ    85.        120.7      THY
+C -CM-CM    85.        120.7
+C -CM-CT     70.       119.7
+C -CA-CT     70.       119.7      wlj
+C -CM-HC     35.       119.7
+C -CM-HA     35.       119.7
+C3-CM-CJ    85.        119.7      THY
+CA-CM-CM    85.        117.0
+CA-C=-CM    85.        117.0
+CA-C#-C#    85.        117.0
+CA-CM-HC     35.       123.3
+CP-CM-HC     35.       123.3
+CA-C=-HC     35.       123.3
+CA-C#-HC     35.       123.3
+CJ-CM-CT     85.       119.7
+CM-CM-CT     70.       124.0      wlj
+CM-CM-CZ     70.       124.0      wlj
+C#-C#-CZ     70.       124.0      wlj
+C#-C#-CT     70.       124.0      wlj
+CM-C=-C=     70.       124.0      wlj
+C#-C=-CM     70.       124.0      wlj
+C#-C#-C=     70.       124.0      wlj
+C#-C#-C#     70.       124.0      wlj
+CM-C=-C      70.       118.7      wlj
+CM-C=-CT     70.       124.0      wlj
+C=-C=-CT     70.       124.0      wlj
+C=-C#-CT     70.       124.0      wlj
+C#-C=-CT     70.       124.0      wlj
+CT-CM-C=     70.       124.0      mwm
+CM-CT-CM     63.       112.4      mwm
+CM-CM-HC     35.       120.0      wlj
+CM-CM-HA     35.       120.0      wlj
+C#-C#-HC     35.       120.0      wlj
+CM-CM-H4     35.       119.7
+CM-C=-HC     35.       120.0      wlj
+C=-CM-HC     35.       120.0      wlj
+C=-C=-HC     35.       120.0      wlj
+C=-CM-HA     35.       120.0      wlj
+C=-C=-HA     35.       120.0      wlj
+CM-C=-HA     35.       120.0      wlj
+C!-C=-HA     35.       120.0      wlj
+N=-C=-HC     35.       120.0      wlj imine check
+CZ-C=-HC     35.       120.0      wlj
+CZ-CM-HC     35.       120.0      wlj
+C#-C=-HC     35.       120.0      wlj
+C=-C#-HC     35.       120.0      wlj
+CT-C -HC     35.       115.0      wlj
+HC-C -HC     35.       115.0      wlj check 
+CA-C -HC     35.       115.0      wlj
+CT-CM-HC     35.       117.0      wlj
+HC-CM-HC     35.       117.0      wlj
+CT-CM-CT     70.       130.0      wlj
+CT-C+-CT    172.8      120.0      wlj JACS 94, 4632 (1972)
+CT-C+-HC    144.0      120.0      wlj          "
+CT-CT-C+     63.0      105.0      wlj
+HC-CT-C+     35.0      105.0      wlj
+CM-C=-N=    70.        121.2
+CM-CM-N*    70.        121.2
+CM-CM-NA    70.        121.2      copy from above for CytH+ (jtr 5-14-91)
+HC-CM-N*     35.       119.1
+HC-CM-NA     35.       119.1      copy from above for CytH+ (jtr 5-14-91)
+CA-CN-CB    85.        122.7      TRP
+CA-CN-NA    70.        132.8    TRP(OL)
+CB-CN-CD    85.        122.7      TRP
+CB-CA-CW    63.0       106.4
+CB-CA-CT    70.        128.6
+CB-CN-NA    70.        104.4
+CD-CN-NA    70.        132.8    TRP(OL)
+HA-CQ-NC     35.       115.45
+H5-CQ-NC     35.       115.45
+NC-CQ-NC    70.        129.1
+HA-CR-NA     35.       120.0
+HA-CX-NA     35.       120.0    jtr: HIP HD2-CD2-NE2
+HA-CR-NB     35.       120.0
+HA-CK-N*     35.       120.0
+HA-CK-NA     35.       120.0      wlj
+HA-CK-NB     35.       120.0      wlj
+NA-CR-NA    70.        106.7    MKD MP2(full)/aug-ccpVTZ  - aminoimidazol,HIP
+NA-CR-NB    70.        110.5    MKD MP2(full)/6-311G(d,p) changed from 120.0
+NA-CR-CT    70.        125.0      wlj
+NA-CR-CA    70.        125.0      wlj
+NB-CR-CT    70.        125.0      wlj
+NA-CR-SY    70.        120.       wlj
+NB-CR-SY    70.        120.       wlj
+NB-CR-S     70.        113.6      wlj
+C -CT-CT    63.0       111.1      AA
+CM-CT-CT    63.0       111.1      " wlj
+CW-CT-HC     35.0      109.5    jtr: HID HB-CB-CG
+CP-CT-HC     35.0      109.5    JT-R 2014/04: thiophenes
+CV-CT-HC     35.0      109.5    jtr: HIE HB-CB-CG
+CX-CT-HC     35.0      109.5    jtr: HIP HB-CB-CG
+C -CT-HC     35.       109.5
+C -CT-N     63.0       110.1      AA     WORK DONE ON 6/23/82
+C -CT-NC    63.0       110.1      wlj
+CS-CT-CT    63.0       115.6    wlj
+CS-CT-HC     35.       109.5    wlj
+CA-CT-CT    63.        114.       PHE(OL)         SCH JPC  79,2379
+CA-CT-HC     35.       109.5
+CA-N3-H3     35.       109.5    wlj anilinium
+CW-CT-CT    63.0       114.0     jtr: HID CA-CB-CG
+CV-CT-CT    63.0       114.0     jtr: HIE CA-CB-CG
+CX-CT-CT    63.0       114.0     jtr: HIP CA-CB-CG
+CM-CT-HC     35.       109.5
+C=-CT-HC     35.       109.5      wlj
+CT-CT-CT     58.35     112.7      CHARMM 22 parameter file
+CF-CF-CF     58.35     112.7      wlj
+C3-CT-C3     40.       109.5
+C2-CT-C2     40.       109.5
+C2-CT-C3     40.       109.5
+C3-CT-C      63.       109.5    from CA-CT-CT 
+CT-CT-HC     37.5      110.7      CHARMM 22           
+CT-HC-DM     37.5      109.47     wlj
+CT-HC-HC      0.        37.0      wlj
+DM-HC-HC      0.       109.47     wlj
+CT-OS-DM    10.0       109.47     wlj
+CA-OS-DM    10.0       109.47     wlj
+CT-OH-DM    10.0       109.47     wlj
+CA-OH-DM    10.0       109.47     wlj
+OH-HO-DM    10.0       109.47     wlj
+HO-OH-DM    10.0       109.47     wlj
+CT-S -DM    10.0       109.47     wlj
+CT-SH-DM    10.0       109.47     wlj
+SH-HS-DM    10.0       109.47     wlj
+CT-F -DM    10.0       109.47     wlj 1/19
+CA-F -DM    10.0       109.47     wlj 1/19
+CT-Cl-DM    10.0       109.47     wlj 1/19
+CA-Cl-DM    10.0       109.47     wlj 1/19
+CT-Br-DM    10.0       109.47     wlj 1/19
+CA-Br-DM    10.0       109.47     wlj 1/19
+CT-I -DM    10.0       109.47     wlj 1/19
+CA-I -DM    10.0       109.47     wlj 1/19
+NZ-CZ-DM    10.0       90.0       wlj
+CA-NT-DM    10.0       109.5      wlj
+NO-ON-DM    10.0       109.5      wlj
+C -N -DM    10.0       109.5      wlj
+DM-ON-DM    10.0       109.5      wlj
+DM-NT-H     10.0       100.       wlj
+DM-N -H     10.0       100.       wlj
+DM-N3-CT    10.0       100.       wlj
+DM-N3-CA    10.0       100.       wlj
+DM-N3-CR    10.0       100.       wlj
+CR-OS-DM    10.0       125.       wlj
+CW-OS-DM    10.0       125.       wlj
+CB-OS-DM    10.0       125.       wlj
+NB-OS-DM    10.0       125.       wlj
+NB-NB-DM    10.0       125.       wlj
+CR-NB-DM    10.0       125.       wlj
+NA-NB-DM    10.0       125.       wlj
+CW-S -DM    10.0       130.       wlj
+NB-S -DM    10.0       130.       wlj
+CR-S -DM    10.0       130.       wlj
+CT-CT-N     80.0       109.7      ALA    JACS 94, 2657
+CT-CT-NM    80.0       109.7      ALA    JACS 94, 2657
+CT-CT-N*     50.       109.5
+CT-CO-N*     50.       109.5      jtr (12/7/01)
+CT-CT-N2    80.0       111.2      ARG   JCP 76, 1439
+C -CT-N3    80.0       111.2      Amino terminal residues
+C -CT-NT    80.0       111.2      wlj
+CA-CT-NT    80.0       111.2      wlj
+CA-CT-NA    80.0       111.2      wlj
+CT-CT-N3    80.0       111.2      LYS(OL)   JCP 76, 1439
+CT-CT-OH     50.       109.5
+CA-CT-OH     50.       109.5      wlj
+CT-CT-OS     50.       109.5
+CA-CT-OS     50.       109.5
+CT-CT-S     50.        114.7      CYX            SCHERAGA  JPC 79,1428
+CT-CT-SH    50.0       108.6      CYS
+CA-CT-S     50.        114.7      wlj
+CW-CT-S     50.        114.7      wlj
+NT-NT-H     35.0       106.0      wlj 1/14
+CT-NT-H     35.0       109.5
+CA-NT-H     35.0       116.0     wlj    anilines 9/06
+CA-NT-CA    50.0       116.0     wlj    anilines 9/06
+CA-NT-CT    50.0       116.0     wlj    anilines 9/06
+CP-NT-H     35.0       116.0     JT-R 2014/04 aminothiophenes, from wlj    anilines 9/06
+CP-NT-CT    50.0       116.0     JT-R 2014/04 aminothiophenes, from wlj    anilines 9/06
+CT-NT-CT    51.8       107.2     wlj - MM3 based JACS 112, 8314 (90)
+CT-NT-CH    51.8       107.2             "
+CT-NT-C2    51.8       107.2             "
+CT-NT-C3    51.8       107.2             "
+CH-NT-CH    51.8       107.2             "
+CH-NT-C2    51.8       107.2             "
+CH-NT-C3    51.8       107.2             "
+C2-NT-C2    51.8       107.2             "
+C2-NT-C3    51.8       107.2             "
+C3-NT-C3    51.8       107.2             "
+HC-CT-HC     33.       107.8      CHARMM 22 
+DM-CM-HC     10.        90.0      wlj
+DM-C=-HC     10.        90.0      wlj
+DM-CM-CM      2.        90.0      wlj
+DM-CZ-CZ      5.        90.0      wlj
+DM-CZ-CA      5.        90.0      wlj
+DM-CZ-HC      5.        90.0      wlj
+DM-CM-C=      2.        90.0      wlj
+DM-C=-C=      2.        90.0      wlj
+DM-C=-CM      2.        90.0      wlj
+DM-DM-DM     33.       109.47     wlj
+DM-HC-DM     33.       109.47     wlj
+DM-HA-DM     33.       109.47     wlj
+DM-HO-DM     33.       109.47     wlj
+DM-HS-DM     33.       109.47     wlj
+DM-H -DM     33.       109.47     wlj
+DM-OS-DM      5.       109.47     wlj
+DM-OH-DM      5.       109.47     wlj
+DM-S -DM      5.       109.47     wlj
+DM-SH-DM      5.       109.47     wlj
+DM-DM-F      10.       180.0      wlj
+DM-DM-Cl     10.       180.0      wlj
+DM-DM-Br     10.       180.0      wlj
+DM-DM-I      10.       180.0      wlj
+D3-D3-D3     33.       120.00     JZV
+D3-D3-DM     33.       120.00     JZV
+DM-DM-D3     33.       109.47     JZV
+D3-DM-D3     33.       109.47     JZV
+DM-D3-DM     33.       120.00     JZV
+CY-CY-HC    37.5       117.2      cyclopropanes - wlj  10/97
+YC-CY-CY    30.0        79.2            "
+CY-CY-CY    30.0        83.0            "
+CY-CY-CT    37.5       117.2            "
+CY-CY-CA    37.5       121.3            "
+CY-CY-CP    37.5       121.3            "
+CY-CT-HC    37.5       110.7            "
+HC-CY-HC     35.       114.3            "
+HC-CY-CT     35.       114.3            "
+CT-CY-CT     35.       114.3            "
+HC-CY-CA     35.       114.0            "
+HC-CY-CP     35.       114.0            "
+CA-CA-CY     70.       120.7            "
+CY-CZ-CZ    150.       180.0            "
+CZ-CY-HC     35.       116.0            "
+CY-CY-CZ     65.       120.0      wlj 6/23
+CY-CM-HC     35.       135.0      wlj
+CY-CY-N$     80.        89.0      small rings - wlj
+CY-N$-C$     50.        94.0            "
+N$-C$-CY     70.        91.0            "
+CY-CY-C$     63.        85.0            "
+N$-C$-O      80.       134.0            "
+CY-C$-O      80.       134.0            "
+HC-CY-N$     35.       111.0            "
+HC-CY-N      35.       108.0            "
+HC-CY-C$    37.5       110.0            "
+CY-CY-N     37.5       126.0            "
+HC-CY-S     37.5       108.0            "
+CY-CY-S      55.       128.0            "
+CY-N -C      55.       128.0            "
+CY-N -H      40.       113.0            "
+N -CY-C$     70.       117.0            "
+N$-CY-S      55.       109.0            "
+C$-N$-CT     55.       127.0            "
+CY-S -CT     62.        94.0            "
+CY-N$-CT     50.       126.0            "
+N$-CT-CT     80.       110.0            "
+N$-CT-HC     35.       109.5            "
+N$-CT-C      80.       113.0            "
+CY-O$-CY     60.        90.0            "
+CY-CY-O$     50.        90.0            "
+CT-CY-O$    37.5       114.0            "
+CA-CY-O$    37.5       114.0            "
+HC-CY-O$    37.5       114.0            "
+HC-CT-N      35.       109.5
+HC-CT-NM     35.       109.5
+HC-CT-N*     35.       109.5      jtr (12/7/01)
+HC-CO-N*     35.       109.5
+HC-CT-NA     35.       109.5      copy from above for CytH+ (jtr 5-14-91)
+HC-CT-N2     35.       109.5
+HC-CT-N3     35.       109.5
+HC-CT-NT     35.       109.5      JACS 115, 9620 (93)
+DM-H -NT     10.       109.5      wlj
+HC-CT-NC     35.       109.5
+HC-CT-OH     35.       109.5
+HC-CT-OS    35.0       109.5      SUG
+HC-CT-S      35.       109.5
+HC-CT-P      41.       109.5      wlj 11/95 MM3 based JACS 114, 8536 (92)
+CT-CT-P      43.       109.5             "
+CA-CT-P      43.       109.5             "
+CT-CT-P+     43.       109.5      wlj 9/97
+CT-P+-CT     45.       109.5      " AMBER OS-P-OS
+HC-CT-P+     41.       109.5      "
+HC-CT-SH     35.       109.5
+N*-CT-OS     50.       109.5
+N*-CO-OS     50.       109.5     jtr (12/7/01)
+CW-CW-NB    70.        120.0 
+HA-CV-NB     35.       121.7     wlj 6/13
+C!-CV-NB     35.       121.7     wlj 6/13
+H4-CW-NA     35.       120.0
+HA-CA-NA     35.       120.0
+C -N -C2    50.        121.9      PRO(OL)
+C -N -C3    50.        121.9      TEST!!!!!!!!
+C -N -CH    50.        121.9      AA(OL)
+C -N -CT    50.        121.9
+C -NM-CT    50.        121.9
+C -N -CA    50.        121.9      wlj
+CA-N2-CA    50.        121.9      wlj
+C -N -H     35.        119.8      AA(OL)
+CQ-NC-DM     5.        119.8      wlj    
+C2-N -C3    50.        121.9
+C -N -H2    35.        120.       GLN,ASN                 **
+C2-N -CH    50.        118.       PRO(OL)         DETAR JACS 99,1232
+C2-N -H     38.        118.4      AA(OL)
+C3-N -H     38.        118.4                  
+CH-N -H     38.        118.4      AA(OL)
+CT-N -CT    50.        118.       PRO(OL)         DETAR JACS 99,1232
+CT-N2-CT    50.        118.       
+CT-NM-CT    50.        118.       PRO(OL)
+CA-N -CT    50.        118.       wlj
+CA-NC-CT    50.        118.       wlj
+CT-N -H     38.        118.4
+H -N -H     35.        120.       ADE,CYT,GUA,GLN,ASN     **
+########                          H -N2-H     35.        113.       wlj 
+H -N2-H     35.        120.      MKD MP2(full)/aug-ccpVTZ  - aminoimidazol, changed from 113.0
+H3-N -H3    35.        120.       ADE,CYT,GUA,GLN,ASN     **
+C -N*-CH    70.        117.6      URA,CYT
+C -N*-CJ    70.        121.6      URA,CYT
+C -N*-CM    70.        121.6      
+C -NA-CM    70.        121.6      copy from above for CytH+ (jtr 5-14-91)
+C -N*-CT     70.       117.6
+C -N*-CO     70.       117.6      jtr 12/11/01
+C -N*-H     35.        119.2
+C3-N*-CB    70.        125.8      9 methylated guan,aden
+C3-N*-CE    70.        128.8      Methylated purines
+C3-N*-CK    70.        128.8
+CB-N*-CE    70.        105.4      GUA,ADE
+CB-N*-CH    70.        125.8      GUA,ADE
+CE-N*-CH    70.        128.8      GUA,ADE
+CE-N*-CT     70.       128.8
+CE-N*-H     35.        127.3
+CH-N*-CJ    70.        121.2      URA,CYT
+CH-N*-CK    70.        128.8
+CJ-N*-CT     70.       121.2
+CJ-N*-H     35.        119.2
+CM-N*-CT     70.       121.2
+CM-N*-CO     70.       121.2       jtr 12/11/01
+CM-N*-H     35.        119.2
+CM-NA-H     35.        119.2       copy from above for CytH+ (jtr 5-14-91)
+C2-N2-CA    50.        123.2       ARG(OL)
+C2-N2-H2    35.        118.4      ARG(OL)
+C2-N2-H3    35.        118.4      ARG(OL)
+C3-N2-CA    50.        123.2       ARG(OL)
+C3-N2-H2    35.        118.4      ARG(OL)
+CA-N2-CT    50.        123.2       ARG(OL)
+CA-N2-H     35.        120.       ARG(OL)
+CQ-N2-H     35.        120.       wlj
+CA-N2-H2    35.        120.       ADE,CYT,GUA,ARG
+CA-N2-H3    35.        120.       ADE,CYT,GUA,ARG
+CT-N2-H3    35.        118.4      ARG(OL)
+CT-N2-H     35.        118.4
+H2-N2-H2    35.        120.       ADE,CYT,GUA,GLN,ASN,ARG
+H3-N2-H3    35.        120.       ADE,CYT,GUA,GLN,ASN,ARG
+C2-N3-H3    35.        109.5      LYS
+C3-N3-H3    35.        109.5
+CT-N3-H3    35.        109.5      LYS
+H3-N3-H3    35.        109.5      LYS
+CT-N3-CT    50.        113.0      proline j.phys chem 1979 p 2361
+CA-N3-CT    55.        114.0      wlj                              
+C -NA-C     70.        126.4      URA
+C -N -C     70.        126.4      wlj
+C -NA-CA    70.        125.2      GUA
+C -N -CQ    70.        125.2      wlj
+C -NA-H     35.        116.8      GUA,URA(2)
+CA-NA-H     35.        118.0      GUA
+CQ-N -H     35.        118.0      wlj
+CG-NA-CN    70.        111.6      TRP(OL)
+CG-NA-CR    70.        107.3      HIS(OL)
+CG-NA-H     35.        126.35      HIS(OL)
+CN-NA-CW    70.        111.6      TRP(OL)
+CN-NA-H     35.        123.1       TRP
+CR-NA-H     35.        124.00      HIS(OL)
+CW-NA-H     35.        124.00      JT-R 2014/04  changed back from 129.2       wlj 6/13
+CX-NA-H     35.        124.00      jtr HIP
+CW-NA-CT    70.        124.00      wlj    
+CB-N*-CK    70.        105.4
+CB-N*-CT    70.        125.8
+CB-N*-CO    70.        125.8       jtr (12/7/01)
+CB-N*-H     30.        125.8
+CK-N*-CT    70.        128.8
+CK-N*-CO    70.        128.8       jtr (12/7/01)
+CK-N*-H     30.        128.8
+CB-NA-CK    70.        105.4       wlj
+CB-NA-CT    70.        125.8       wlj
+CB-NA-H     30.        125.8       wlj
+CK-NA-CT    70.        128.8       wlj
+CK-NA-H     30.        128.8       wlj
+CB-NB-CE    70.        103.8      GUA,ADE
+CB-NB-CK    70.        103.8
+CR-NB-CR    70.        110.0      JT-R thiadiazoles
+CR-NB-CV    70.        104.0      wlj ai purine 6/14
+CR-NB-CB    70.        110.0      wlj
+CR-NB-CW    70.        110.0
+C -NC-CA    70.        120.5      CYT
+C -NC-CT    70.        120.5      imine - check
+C -N=-C=    70.        120.5      imine - check
+CA-NC-CB    70.        112.2      GUA
+CM-NC-CB    70.        112.2      GUA
+CA-NC-CI    70.        118.6      ADE
+CA-NC-CQ    70.        118.6
+CQ-NC-CQ    70.        118.6      wlj 1,3,5-triazine
+CB-NC-CI    70.        111.0      ADE
+CB-NC-CQ    70.        111.0
+CR-NC-CQ    70.        111.0      wlj
+C2-NT-H     43.2       108.1      wlj MM3 based
+C3-NT-H     43.2       108.1      wlj MM3 based
+CH-NT-H     43.2       108.1      wlj MM3 based
+H -NT-H     43.6       106.4      wlj MM3 based           
+H -N3-H     43.6       109.5      wlj            
+H -N -OH    35.        110.2      wlj
+C -N -OH    46.        115.7      wlj
+N -OH-HO    49.        105.4      wlj
+C -OH-HO    35.        113.0      TYR(PHENOL)     HARMONY MEOH
+CA-OH-HO    35.        113.0
+CP-OH-HO    35.        109.0     JT-R 2014/04 hydroxy thiophene
+C -O -DM    35.        113.0
+DM-O -DM    10.        117.0
+CM-OH-HO    35.        109.0      wlj
+C2-OH-HO    55.0       108.5      SUG,SER(OL,mod)
+C3-OH-HO    55.0       108.5      SUG,SER(OL,mod)
+CH-OH-HO    55.0       108.5      THR(OL),SUG
+CT-OH-HO     55.       108.5      
+HO-OH-P     55.0       108.5      SUG(OL)
+C2-OS-C2    100.0      111.8       DME based
+C2-OS-C3    100.0      111.8       DME based
+CH-C -OS    81.        111.4    from FK506, SKF8
+C -OS-CH    83.        116.9    from FK506 C -OS-CZ for SKF8
+C -OS-C2    83.        116.9
+C -OS-C3    83.        116.9
+O -C -OS    83.        123.4    J.Comp.Chem.1990,11,1181 for SKF8
+C -OS-CT    83.        116.9       "
+OS-C -CT    81.        111.4       "
+OS-C -CA    81.        111.4      wlj
+C -OS-CA    83.        116.9      wlj
+CA-CH-OS    80.0       109.5    SUG from AMBER/BOSS for SKF8
+OS-CO-OH     92.6      111.55   Ha,CarbRes 180,207(88)Merz,JCC 15,1019 (94)
+OS-CO-OS     92.6      111.55     ACETAL - wlj 2/93
+C3-OS-CO    100.0      113.0        "
+C2-OS-CO    100.0      113.0        "
+CH-OS-CO    100.0      113.0        "
+C2-CO-OS    80.0       109.5        "
+C3-CO-OS    80.0       109.5        "
+C3-CO-C3    40.0       109.5        "
+C2-C2-CO    63.0       112.4        "
+C3-C2-CO    63.0       112.4        "
+OS-CO-CT    50.        109.5       hexopyranoses :  CT-CT-OS - wd 3/95 Glucose
+CO-CT-CT    58.35      112.7        "            :  CT-CT-CT - wd 6/95 Glucose
+CT-CO-OH    50.        109.5        "            :  CT-CT-OH - wd 6/95 Glucose
+CT-CO-HC    37.5       110.7        "            :  CT-CT-HC - wd 6/95 Glucose
+CO-OH-HO    55.        108.5        "            :  CT-OH-HO - wd 6/95 Glucose
+OS-CO-HC    35.0       109.5        "            :  HC-CT-OS - wd 6/95 Glucose
+CO-OS-CT    60.        109.5        "            :  CT-OS-CT - wd 6/95 Glucose
+CO-CT-HC    37.5       110.7        "            :  CT-CT-HC - wd 6/95 Glucose
+CO-CT-OH    50.        109.5        "            :  CT-CT-OH - wd 6/95 Glucose
+OH-CO-HC    35.0       109.5        "            :  HC-CT-OS - wd 6/95 Glucose
+HC-CO-HC    33.        109.5        "            :  HC-CT-HC - wd 6/95
+C2-OS-HO    55.0       108.5      SUG
+CA-OS-P     100.0      120.5      mll
+C2-OS-P     100.0      120.5      SUG(OL)
+C3-OS-P     100.0      120.5     DMPhos based
+CH-OS-CH    100.0      111.8      SUG(dme based)
+CH-OS-HO    55.0       108.5      SUG
+CH-OS-P     100.0      120.5      SUG
+CT-OS-CT     60.       109.5
+Si-OS-Si     20.       145.0      wlj
+CT-OS-Si     40.       121.0      wlj
+Si-OH-HO     40.       117.0      wlj
+CT-Si-OS     60.       105.0      wlj
+CT-Si-OH     60.       107.0      wlj
+CT-Si-CT     37.       112.5      wlj fit to expt
+CT-CT-Si     40.       114.0      wlj fit to expt
+CA-Si-CT     40.       112.5      wlj
+CA-CA-Si     45.       121.0      wlj
+CT-Si-Si     40.       112.0      wlj
+H -Si-Si     25.       110.5      wlj
+OS-Si-OS     60.       110.0      wlj
+Si-CT-HC     35.       110.9      wlj fit to expt
+H -Si-H      33.       109.0      wlj fit to expt
+H -Si-CT     28.       110.5      wlj fit to expt
+H -Si-OH     35.       111.0      wlj
+H -Si-OS     35.       111.0      wlj
+H -Si-CA     30.       110.0      wlj
+F -Si-CT     35.       110.5      wlj
+Cl-Si-CT     35.       110.5      wlj
+Br-Si-CT     35.       110.5      wlj
+I -Si-CT     35.       110.5      wlj
+CT-OS-CA     75.       111.0      wlj 9/97
+########                          CA-OS-CA     75.       111.0      wlj 9/08
+CA-OS-CA     75.       116.3    MKD MP2(full)/6-311G(d,p) - biaryl ethers, changed from 111.0
+CT-OS-CM     75.       111.0      wlj
+CT-OS-P     100.       120.5
+CT-OH-P     100.       120.5      jtr 12/10/01
+O -C -O2     80.       126.0      adk
+O2-P -O2    140.0      119.9      SUG(OL)
+O2-P -OH    45.0       108.23     SUG(OL)
+O2-P -OS    100.0      108.23     SUG(OL)
+OH-P -OS    45.0       102.6      SUG(OL)
+OS-P -OS    45.0       102.6      SUG(OL)
+O -P -OH    100.0      108.23     SUG(OL)
+O -P -OS    100.0      108.23     SUG(OL)
+OH-P -OH    45.0       102.6      SUG(OL)
+CT-P -OS    45.0       109.5      wlj 11/95
+CT-P -O2    45.0       109.5      wlj 11/95
+CT-P -O     45.0       109.5      wlj 11/95
+CA-P -OS    45.0       109.5      wlj 11/95
+CA-P -OH    45.0       109.5      wlj 11/95
+CA-P -O     45.0       109.5      wlj 11/95
+C2-S -C3    62.         98.9       MET(OL)
+C2-S -LP    150.        96.7
+C2-S -S     68.        103.7       CYX(OL)        SCHERAGA  JPC 79,1428
+C3-S -LP    150.        96.7
+C3-S -S     68.        103.7       CYX(OL)        SCHERAGA  JPC 79,1428
+CT-S -CT    62.         98.9       MET(OL)
+CR-S -CW    74.         90.0       wlj
+CW-S -CW    74.         97.0       wlj
+CB-S -CB    74.         97.0       wlj
+CB-S -N     74.         92.4       wlj
+CR-S -CB    74.         97.0       wlj
+CW-S -CB    74.         97.0       wlj
+CT-S -LP    150.        96.7
+CT-S -S     68.        103.7       CYX(OL)        SCHERAGA  JPC 79,1428
+LP-S -LP     10.       160.0
+LP-S -S     150.        96.7
+C2-SH-HS    44.         96.0        CYS(OL)
+C2-SH-LP    150.        96.7
+C3-SH-HS    44.         96.0        CYS(OL)
+C3-SH-LP    150.        96.7
+CT-SH-HS    44.         96.0        CYS(OL)
+CA-SH-HS    50.         96.0        wlj
+CT-SH-LP    150.        96.7
+HS-SH-HS     35.        92.07
+HS-SH-LP    150.        96.7
+LP-SH-LP     10.       160.0
+P -OS-P     100.       120.5
+C9-C8-C8    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-C8    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-C8    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-C8    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C8-CT    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C8-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C8-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C8-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C8-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C8-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C8-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C8-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C8-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C3-C8-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C7-CT    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C7-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C7-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C7-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C7-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C7-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C7-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C7-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C7-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C3-C7-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CA-OS-C2   100.0       111.8    AMBER(MMOD) 9/9/91
+CA-CT-CA    40.0       109.5      "
+CA-CT-C2    63.0       114.0      "           
+CA-CT-C     63.0       112.0    wlj
+N -CT-C2    80.        109.7    Added DSM (from N -CT-C3)
+HC-CT-C2    35.        109.5    Added DSM (from C -CT-HC)
+C -CT-C2    63.        111.1    Added DSM (from C3-CT-C )
+CT-CA-NA    70.        120.00   Added DSM (from CT-CC-NA)
+CA-NA-CA    70.        125.2    Added DSM (from C -NA-CA)
+CA-CA-NB    70.        108.7    Added DSM (from CA-CA-NA)
+NA-CA-NB    70.        123.3    Added DSM (from NA-CA-NC)
+CA-NB-CA    70.        125.2    Added DSM (from C -NA-CA)
+HA-CA-NB     35.       119.1    Added DSM (from HC-CM-NA)
+CA-CA-N     70.        120.0    Added DSM (from CA-CA-NA)
+CA-N -H     35.        119.8    Added DSM (from C -N -H)
+NA-CM-N     70.        120.0    wlj
+CM-N -H     35.        119.8    wlj
+C=-N -H     35.        119.8    wlj                         
+CU-N -H     35.        119.8    wlj                         
+CW-N -H     35.        119.8    wlj                         
+CS-N -H     35.        119.8    wlj                         
+CB-CT-HC     35.       109.5    Added DSM (from CA-CT-HC)
+CA-CB-CT    70.        120.     Added DSM (from CA-CA-CT)
+CB-CA-NA    70.        108.7    Added DSM (from CA-CA-NA)
+CB-CB-CT    70.        120.     Added DSM (from CA-CA-CT)
+CB-CT-CT    63.        114.     Added DSM (from CA-CT-CT)
+CT-CT-F     50.        109.5    PAK F-CT-HC (emd 5-09-94)
+CF-CF-F     50.        109.5    wlj
+C2-C2-F     50.        109.5
+CA-CT-F     50.        109.5    wlj 
+CA-CF-F     50.        109.5    wlj 
+CM-CT-F     50.        109.5    wlj 
+F -CT-F     77.        109.1    PAK F-CT-F  (emd 5-09-94)
+F -CF-F     77.        109.1    wlj                        
+HC-CT-F     40.        107.0    wlj
+CT-C -C     80.        117.2    (JP 1-6-91)  SKF8
+C -C -O     80.        121.4    ketone (JP 1-5-91) SKF8
+C -C -N     70.        116.6    (JP 1-5-91) SKF8
+C9-C8-SY    70.        118.
+C8-SY-C3    62.        98.9
+OY-SY-N    120.0      107.0
+OY-SY-OH    74.0      108.7
+SY-OH-HO    74.0      110.0 
+OY-SZ-CT    74.0      107.0
+OY-SY-CT    74.0      108.9
+OY-SY-CA    74.       107.2
+N -SY-CA   100.       103.0
+SY-CA-CA    85.       119.4
+SY-CT-HC    35.0      109.5
+SZ-CT-HC    35.0      109.5
+CT-SY-CT    62.0      102.0       
+CA-SY-CT    62.0      102.0
+CR-SY-CT    62.0      102.0
+CT-SY-F     62.0       96.1                wlj 9/19 MP2/6-311+Gdp
+CA-SY-F     62.0       96.1                wlj 9/19              
+CT-SY-OY    74.0      110.5                wlj 9/19
+CA-SY-OY    74.       107.2                wlj 9/19
+OY-SY-F     62.0      106.2                wlj 9/19
+CA-OS-SY    62.0      123.0
+OS-SY-F     62.0      107.0
+OS-SY-OY    62.0      107.0
+CT-SZ-CT    62.0       96.0
+CT-CT-SY    50.0      108.6
+CT-CT-SZ    50.0      108.6
+OH-SY-CT    75.0       96.4
+OH-SY-CA    75.0       96.4
+N -SY-CT   100.0      103.0
+SY-N -CT    50.       120.0
+H -N -SY   100.0      111.0
+OS-C -N     81.        111.4    bhap,                   copy from OS-C -CT      rcr HIVRT
+CT-NT-SY    50.0      108.6     bhap,                   copy from CT-CT-SY      rcr HIVRT
+C -CT-F     50.        109.5    bhap,                   copy from CT-CT-F       rcr HIVRT
+SY-CT-F     50.        109.5    bhap,                   copy from CT-CT-F       rcr HIVRT
+SY-NT-H     35.0       115.0    bhap,                   adjusted from CT-NT-H   rcr HIVRT
+C -CW-NA    85.        120.     bhap,                   copy from C -CA-CA      rcr HIVRT
+NT-C -CW    70.        116.0    bhap,                   copy from CT-C -CT      rcr HIVRT
+C -CW-CS    85.        120.     bhap,                   copy from C -CA-CA      rcr HIVRT
+CB-CS-HA     35.       120.0    bhap,                   copy from CB-CA-HA      rcr HIVRT
+CW-C -O     80.        120.4    bhap,                   copy from CA-C -O       rcr HIVRT
+C -NT-CT    63.0       111.1    bhap,                   copy from C -CT-CT      rcr HIVRT
+C -CT-C     63.0       111.1    lac,                    copy from C -CT-CT      rcr HIVRT
+C -CT-OS     50.       109.5    lac,                    copy from CT-CT-OS      rcr HIVRT
+N -CT-OS     50.       109.5    lac,                    copy from CT-CT-OS      rcr HIVRT
+NT-C -O     80.        120.4    nev,                    copy from CT-C -O       rcr HIVRT
+NT-C -CT    70.        116.0    nev,                    copy from CT-C -CT      rcr HIVRT
+CA-NT-C     63.0       112.0    nev,                    copy from CA-CT-C       rcr HIVRT
+CA-NT-SY    50.0      108.6     nev,                    copy from CT-CT-SY      rcr HIVRT
+OY-SY-NT    74.0      108.9     nev,                    copy from OY-SY-CT      rcr HIVRT
+NT-SY-CT    62.0      102.0     nev,                    copy from CT-SY-CT      rcr HIVRT
+NT-CT-S     50.        114.7    nev,                    copy from CT-CT-S       rcr HIVRT
+HC-CY-NT     35.       114.3    nev,                    copy from HC-CY-CT      rcr HIVRT
+CY-CY-NT    37.5       117.2    nev,                    copy from CY-CY-CT      rcr HIVRT
+CA-NT-CY    50.        109.5    nev,                    copy from CA-NT-CT      rcr HIVRT
+NC-CA-Cl    75.        120.0    nev,                    copy from CA-CA-Cl      rcr HIVRT
+NC-CA-NT     70.       116.0    nev,                    copy from NC-CA-CT      rcr HIVRT
+CM-CM-CY     70.       124.0    hept,                   copy from CM-CM-CT      rcr HIVRT
+CM-CY-HC     35.       109.5    hept,                   copy from CM-CT-HC      rcr HIVRT
+CM-CY-CY    63.        114.     hept,                   copy from CA-CT-CT      rcr HIVRT
+C -CM-CY     70.       119.7    hept,                   copy from C -CM-CT      rcr HIVRT
+N*-CM-CT    70.        120.     hept,                   copy from PHE(OL)       rcr HIVRT
+NA-CM-CT    70.        120.     hept,                   copy from PHE(OL)       rcr HIVRT
+S -CM-CM    85.        119.4    hept,                   copy from SY-CA-CA      rcr HIVRT
+S -CM-N*    85.        119.4    hept,                   copy from SY-CA-CA      rcr HIVRT
+S -CM-NA    85.        119.4    hept,                   copy from SY-CA-CA      rcr HIVRT
+N*-CM-OS    70.        120.     hept,                   copy from CA-CA-OS      rcr HIVRT
+NA-CM-OS    70.        120.     hept,                   copy from CA-CA-OS      rcr HIVRT
+CA-S -CM    62.        104.2    hept,                   adjusted from CT-S -CT  rcr HIVRT
+CM-OS-CA    75.        111.0    hept,                   copy from CT-S -CT      rcr HIVRT
+CM-CT-CA    40.0       109.5    hept,                   copy from CA-CT-CA      rcr HIVRT
+S -CA-CA    85.        119.4    thioanisole             copy from SY-CA-CA      rcr HIVRT
+P -CA-CA    85.        119.4    
+CA-S -CT    65.         97.0    thioanisole JT-R 2014/04 MP2/cc-pVTZ (was 62,104.2 adj. rcr HIVRT)
+CZ-S -CT    65.        100.0    wlj 9/06 
+C -N -Zn    20.        126.                             Merz, JACS 113, 8262 (1991)
+HO-OH-Zn   100.        126.
+N -Zn-N     20.        109.5
+N -Zn-O     20.        109.5
+SA-CP-CY    70.        121.1    JT-R 2014/04 cyclopropyl thiophene MP2/aug-cc-pVTZ
+CS-CP-CY    70.        128.4    JT-R 2014/04 cyclopropyl thiophene MP2/aug-cc-pVTZ
+SA-CP-NT    70.        120.8    JT-R 2014/04 amino thiophene MP2/aug-cc-pVTZ
+CS-CP-NT    70.        128.6    JT-R 2014/04 amino thiophene MP2/aug-cc-pVTZ
+SA-CP-CV    70.        111.0    MKD New Thiophene MP2(full)/6-311G(d,p)
+SA-CP-CS    70.        111.0    MKD New Thiophene MP2(full)/6-311G(d,p)
+SA-CP-HA    35.        120.0    MKD New Thiophene MP2(full)/6-311G(d,p)
+CS-CP-HA    35.        128.2    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-CS-HA    35.        123.1    MKD New Thiophene MP2(full)/6-311G(d,p)
+CS-CS-CP    70.        112.3    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-C!-CA    63.        120.5    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-C!-NC    63.        116.8    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-C!-NA    63.        117.2    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-C!-C=    63.        123.8    MKD New Thiophene MP2(full)/6-311G(d,p)   
+SA-CP-C!    63.        121.7    MKD New Thiophene MP2(full)/6-311G(d,p)
+CS-CP-C!    63.        127.7    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-CS-C!    63.        123.6    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-SA-CP    70.         92.2    MKD New Thiophene MP2(full)/6-311G(d,p)
+CR-SA-CR    70.         92.2    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-SA-NB    70.         92.2    MKD New Thiophene MP2(full)/6-311G(d,p)
+NC-C!-NC    70.        126.3    MKD MP2(full)/6-311G(d,p) new
+C!-CR-NA    70.        123.1    MKD MP2(full)/6-311G(d,p) new
+CR-C!-NC    70.        116.6    MKD MP2(full)/6-311G(d,p) new
+CV-C!-NC    70.        116.6    wlj 6/13                       
+CW-C!-NC    70.        117.1    MKD MP2(full)/6-311G(d,p) new
+C=-C!-NA    70.        119.6    MKD MP2(full)/6-311G(d,p) new
+C -NA-C!    70.        126.6    MKD MP2(full)/6-311G(d,p) new
+C!-NA-H     35.        118.0    MKD MP2(full)/6-311G(d,p) new
+C=-CM-C     85.        121.7    MKD MP2(full)/6-311G(d,p) new
+HC-C=-C!    35.        119.9    MKD MP2(full)/6-311G(d,p) new
+CW-C!-NA    70.        116.4    MKD MP2(full)/6-311G(d,p) new
+C=-C!-CW    63.        124.7    MKD MP2(full)/6-311G(d,p) new
+C!-C=-C=    70.        118.1    MKD MP2(full)/6-311G(d,p) new
+CS-C!-NC    63.        117.0    MKD MP2(full)/6-311G(d,p) new
+C!-NA-CW    63.        125.2    MKD MP2(full)/6-311G(d,p) new
+NA-C!-NC    63.        116.2    MKD MP2(full)/6-311G(d,p) new
+CS-C!-NA    63.        116.8    MKD MP2(full)/6-311G(d,p) new
+C=-C!-CS    63.        124.2    MKD MP2(full)/6-311G(d,p) new
+C!-C!-NA    63.        116.6    MKD MP2(full)/6-311G(d,p) new
+C=-C!-C!    63.        123.9    MKD MP2(full)/6-311G(d,p) new
+CR-C!-NA    63.        114.3    MKD MP2(full)/6-311G(d,p) new
+C=-C!-CR    63.        126.0    MKD MP2(full)/6-311G(d,p) new
+NA-C!-CA    63.        119.8    MKD MP2(full)/6-311G(d,p) new
+C!-NA-NB    63.        119.9    MKD MP2(full)/6-311G(d,p) new
+NA-C!-NA    63.        115.7    MKD MP2(full)/6-311G(d,p) new only give NA-C!-NX in paper?
+NX-C!-NC    63.        116.2    MKD synonym for NA-C!-NC  
+NX-CW-HA    35.        121.6    MKD synonym for HA-CW-NA
+NX-CW-CS    70.        107.7    MKD synonym for NA-CW-CS
+CW-NX-C!    63.        125.2    MKD synonym for C!-NA-CW
+CW-NX-CW    70.        109.8    MKD synonym for CW-NA-CW
+NX-C!-CA    63.        119.8    MKD synonym for NA-C!-CA
+C!-NX-NB    63.        119.9    MKD synonym for C!-NA-NB   
+NB-NX-CW    56.        113.1    MKD synonym for NB-NA-CW
+NX-C!-NA    63.        115.7    MKD synonym for NA-C!-NA
+C=-C!-NX    63.        123.8    MKD MP2(full)/6-311G(d,p) - new - external NA connected to pyridone
+HA-CU-CS    35.        129.2    MKD MP2(full)/6-311G(d,p) - new pyrazole
+CU-NB-NX    70.        104.1    MKD synonym for CU-NB-NA
+HA-CS-CU    35.        128.5    MKD MP2(full)/6-311G(d,p) - new pyrazole
+N2-CR-NA    70.        126.65   MKD MP2(full)/aug-ccpVTZ  - aminoimidazol
+H -N2-CR    35.        120.     MKD MP2(full)/aug-ccpVTZ  - aminoimidazol
+NE-C -NE    70.        105.8    MKD MP2(full)/6-311G(d,p) - hydantoin
+O -C -NE    70.        127.5    MKD MP2(full)/6-311G(d,p) - hydantoin
+CT-NE-C     70.        112.5    MKD MP2(full)/6-311G(d,p) - hydantoin
+C -CT-NE    70.        102.8    MKD MP2(full)/6-311G(d,p) - hydantoin
+HC-CT-NE    35.        109.5    MKD MP2(full)/6-311G(d,p) - hydantoin
+C!-NE-C     63.        124.0    MKD MP2(full)/6-311G(d,p) - hydantoin
+CA-C!-NE    63.        120.0    MKD 
+CT-NE-CT    70.        123.2    MKD MP2(full)/6-311G(d,p) - hydantoin
+C -NE-C     70.        112.1    MKD MP2(full)/6-311G(d,p) - hydantoin
+CT-C -NE    70.        105.8    MKD MP2(full)/6-311G(d,p) - hydantoin
+H -NE-C     35.        112.5    MKD MP2(full)/6-311G(d,p) - hydantoin
+H -NE-CT    35.        123.2    MKD MP2(full)/6-311G(d,p) - hydantoin
+CT-CT-NE    70.        109.5    MKD 
+C!-NC-NC    70.        117.0    MKD synonym for CA-NC-NC
+CQ-NC-NC    70.        118.2    MKD MP2(full)/6-311G(d,p)
+NB-CR-NB    70.        112.2    MKD MP2(full)/6-311++G(d,p) - negatively charged tetrazole
+NB-NB-NB    70.        109.4    MKD MP2(full)/6-311++G(d,p) - negatively charged tetrazole
+NB-NB-SA    70.        114.0       JT-R thiatriazole
+N -OS-CB     70.       104.5     "
+NB-OA-CR     70.       101.3       JT-R oxatriazole 
+NB-OA-NB     70.       103.4       JT-R oxatriazole 
+NB-SA-NB     70.        87.6       JT-R thiatriazole 
+NB-CR-OA     70.       115.0     "
+NB-CR-SA     70.       115.0     "
+CR-NB-SA     70.       110.8       JT-R thiatriazole
+CR-OS-CW     70.       104.0     "
+CV-CW-OS     70.       108.0     "
+HA-CR-OA     35.       117.0     "
+OS-CM-HC     35.       114.5
+CB-CA-HA     35.       120.0
+CB-CA-N2    70.        123.5    ADE
+CB-CA-NC    70.        117.3    ADE
+CD-CA-CD    85.        120.     PHE(OL)
+CJ-CA-N2    70.        120.1    CYT
+CJ-CA-NC    70.        121.5    CYT
+CM-CA-N2    70.        120.1
+CA-CA-N2    70.        120.1    wlj
+CM-CA-NC    70.        121.5
+C=-CA-NC    70.        121.5
+CM-CA-NA    70.        121.5    copy from above for CytH+ (jtr 5-14-91)
+CN-CA-HA     35.       120.0
+NY-CA-NY    70.        111.8    jtr: neutral ARG
+NC-CA-NY    70.        124.1    jtr: neutral ARG
+CA-NC-H     35.        113.0    jtr: neutral ARG
+CA-NY-H     50.        112.5    jtr: neutral ARG
+CA-NY-CT    50.        120.5    jtr: neutral ARG
+H -NY-H     43.6       106.4    jtr: neutral ARG
+CT-NY-H     35.        109.5    jtr: neutral ARG
+CT-CT-NY    80.0       111.2    jtr: neutral ARG
+HC-CT-NY     35.       109.5    jtr: neutral ARG
+N2-CA-N2    70.        120.       ARG(OL)
+N2-CA-NA    70.        116.0    GUA
+N -C=-NA    70.        116.0    GUA
+N2-CA-NC    70.        119.3    ADE,GUA
+N -C=-NC    70.        119.3    ADE,GUA
+N2-CQ-NC    70.        119.3    wlj    
+N2-CQ-N     70.        116.0    wlj
+NA-CA-NC    70.        123.3    GUA
+C -CB-CB    85.        119.2    GUA
+C -CB-NB    70.        130.     GUA
+N -CQ-NC    70.        123.3    wlj
+C -CS-CW    70.        130.     wlj
+C -CB-CW    70.        130.     wlj
+CA-CB-CA    85.        134.9     TRP(OL)
+CS-CB-CA    85.        134.9     
+CS-CB-CD    85.        134.9     
+CS-CB-CN    85.        108.8     
+CA-CB-CB    85.        117.3    ADE
+C!-CB-CB    85.        117.3    ADE
+CA-CB-CN    85.        116.2     TRP
+CA-CB-NB    70.        132.4    ADE
+CB-CB-N*    70.        106.2    GUA,ADE
+CB-CB-NA    70.        106.2    wlj
+CS-CR-NA    70.        106.2    wlj
+CB-CB-NB    70.        111.0    GUA,ADE
+CR-CS-CW    70.        110.4    wlj
+CB-CB-NC    70.        127.7    GUA,ADE
+CB-CB-N     70.        127.7    wlj
+CS-CR-NC    70.        127.7    wlj
+CD-CB-CN    85.        116.2     TRP
+N*-CB-NC    70.        126.2    GUA,ADE
+NA-CB-NC    70.        126.2    wlj
+NB-CB-N     70.        126.2    wlj
+NB-CR-N     70.        126.2    wlj
+NA-CR-NC    70.        126.2    wlj
+C!-CR-OS    70.        122.0    wlj 12/06
+########                        C!-CR-NB    70.        130.0    wlj 12/06
+C!-CR-NB    70.        125.2    MKD MP2(full)/6-311G(d,p) changed from 130.0
+CR-NB-NB    70.        109.0    wlj 12/06
+CV-NB-NB    70.        109.3    wlj 6/13 
+CR-OS-CR    70.        107.0    wlj 12/06
+CW-CW-NA    70.        120.0
+C -CD-CD    85.        120.     TYR(OL)
+CA-CD-CD    85.        120.     PHE
+CB-CD-CD    85.        120.      TRP(OL)
+CD-CD-CD    85.        120.     PHE(OL)
+CD-CD-CN    85.        120.     TRP(OL)
+N*-CE-NB    70.        113.9    ADE,GUA
+CA-CA-NA    70.        108.7     TRP(OL)
+C -CH-C2    63.0       111.1      AA
+C -CH-C3    63.0       111.1      ALA
+C -CH-CH    63.0       111.1      ILE
+C -CH-N     63.0       110.1      AA     WORK DONE ON 6/23/82
+C -CH-NT    80.0       109.7      AA
+C2-CH-CH    63.0       111.5      SUG,ILE
+C2-CH-N     80.0       109.7      ALA    JACS 94, 2657
+C2-CH-N*    80.0       109.5      SUG
+C2-CH-OS    80.0       109.5      SUG
+C3-CH-C3    63.0       111.5      VAL
+C3-CH-CH    63.0       111.5      ILE
+C3-CH-N     80.        109.5                 **
+C3-CH-OH    80.0       109.5      THR
+CH-CH-CH    63.0       111.5      SUG
+CH-CH-N     80.0       109.7      ILE    JACS 94, 2657
+CH-CH-N*    80.0       109.5      SUG
+CH-CH-OH    80.0       109.5      THR,end sugar
+CH-CH-OS    80.0       109.5      SUG
+N*-CH-OS    80.0       109.5      SUG
+NC-CI-NC    70.        129.1      ADE
+C -CJ-CJ    85.        120.7      URA
+CA-CJ-CJ    85.        117.0      CYT
+CJ-CJ-N*    70.        121.2      CYT
+CM-CJ-N*    70.        121.2      THY
+N*-CK-NB    70.        113.9
+NA-CK-NB    70.        113.9      wlj
+NA-CK-H5    35.        123.05
+N*-CK-H5    35.        123.05
+NB-CK-H5    35.        123.05
+C -CM-C3    85.        119.7      THY
+C -CM-CJ    85.        120.7      THY
+C -CM-CM    85.        120.7
+C -CM-CT     70.       119.7
+C -CA-CT     70.       119.7      wlj
+C -CM-HC     35.       119.7
+C -CM-HA     35.       119.7
+C3-CM-CJ    85.        119.7      THY
+CA-CM-CM    85.        117.0
+C=-CM-CM    85.        117.0
+CA-C=-CM    85.        117.0
+CA-C#-C#    85.        117.0
+CA-CM-HC     35.       123.3
+CP-CM-HC     35.       123.3
+CA-C=-HC     35.       123.3
+CA-C#-HC     35.       123.3
+CJ-CM-CT     85.       119.7
+CM-CM-CT     70.       124.0      wlj
+CM-CM-CZ     70.       124.0      wlj
+C#-C#-CZ     70.       124.0      wlj
+C#-C#-CT     70.       124.0      wlj
+CM-C=-C=     70.       124.0      wlj
+C#-C=-CM     70.       124.0      wlj
+C#-C#-C=     70.       124.0      wlj
+C#-C#-C#     70.       124.0      wlj
+CM-C=-C      70.       118.7      wlj
+CM-C=-CT     70.       124.0      wlj
+C=-C=-CT     70.       124.0      wlj
+C=-C#-CT     70.       124.0      wlj
+C#-C=-CT     70.       124.0      wlj
+CT-CM-C=     70.       124.0      mwm
+CM-CT-CM     63.       112.4      mwm
+CM-CM-HC     35.       120.0      wlj
+C#-C#-HC     35.       120.0      wlj
+CM-CM-H4     35.       119.7
+CM-C=-HC     35.       120.0      wlj
+C=-CM-HC     35.       120.0      wlj
+C=-C=-HC     35.       120.0      wlj
+C=-CM-HA     35.       120.0      wlj
+C=-C=-HA     35.       120.0      wlj
+CM-C=-HA     35.       120.0      wlj
+C!-C=-HA     35.       120.0      wlj
+N=-C=-HC     35.       120.0      wlj imine check
+CZ-C=-HC     35.       120.0      wlj
+CZ-CM-HC     35.       120.0      wlj
+C#-C=-HC     35.       120.0      wlj
+C=-C#-HC     35.       120.0      wlj
+CT-C -HC     35.       115.0      wlj
+HC-C -HC     35.       115.0      wlj check 
+CA-C -HC     35.       115.0      wlj
+CT-CM-HC     35.       117.0      wlj
+HC-CM-HC     35.       117.0      wlj
+CT-CM-CT     70.       130.0      wlj
+CT-C+-CT    172.8      120.0      wlj JACS 94, 4632 (1972)
+CT-C+-HC    144.0      120.0      wlj          "
+CT-CT-C+     63.0      105.0      wlj
+HC-CT-C+     35.0      105.0      wlj
+CM-C=-N=    70.        121.2
+CM-CM-N*    70.        121.2
+CM-CM-NA    70.        121.2      copy from above for CytH+ (jtr 5-14-91)
+HC-CM-N*     35.       119.1
+HC-CM-NA     35.       119.1      copy from above for CytH+ (jtr 5-14-91)
+CA-CN-CB    85.        122.7      TRP
+CA-CN-NA    70.        132.8    TRP(OL)
+CB-CN-CD    85.        122.7      TRP
+CB-CA-CW    63.0       106.4
+CB-CA-CT    70.        128.6
+CB-CN-NA    70.        104.4
+CD-CN-NA    70.        132.8    TRP(OL)
+HA-CQ-NC     35.       115.45
+H5-CQ-NC     35.       115.45
+NC-CQ-NC    70.        129.1
+HA-CR-NA     35.       120.0
+HA-CX-NA     35.       120.0    jtr: HIP HD2-CD2-NE2
+HA-CR-NB     35.       120.0
+HA-CK-N*     35.       120.0
+HA-CK-NA     35.       120.0      wlj
+HA-CK-NB     35.       120.0      wlj
+NA-CR-NA    70.        106.7    MKD MP2(full)/aug-ccpVTZ  - aminoimidazol,HIP
+NA-CR-NB    70.        114.0    wlj ai purine 6/14                           
+NA-CR-CT    70.        125.0      wlj
+NA-CR-CA    70.        125.0      wlj
+NB-CR-CT    70.        125.0      wlj
+NA-CR-SY    70.        120.       wlj
+NB-CR-SY    70.        120.       wlj
+NB-CR-S     70.        113.6      wlj
+C -CT-CT    63.0       111.1      AA
+CM-CT-CT    63.0       111.1      " wlj
+CW-CT-HC     35.0      109.5    jtr: HID HB-CB-CG
+CP-CT-HC     35.0      109.5    JT-R 2014/04: thiophenes
+CV-CT-HC     35.0      109.5    jtr: HIE HB-CB-CG
+CX-CT-HC     35.0      109.5    jtr: HIP HB-CB-CG
+C -CT-HC     35.       109.5
+C -CT-N     63.0       110.1      AA     WORK DONE ON 6/23/82
+C -CT-NC    63.0       110.1      wlj
+CS-CT-CT    63.0       115.6    wlj
+CS-CT-HC     35.       109.5    wlj
+CA-CT-CT    63.        114.       PHE(OL)         SCH JPC  79,2379
+CA-CT-HC     35.       109.5
+CA-N3-H3     35.       109.5    wlj anilinium
+CW-CT-CT    63.0       114.0     jtr: HID CA-CB-CG
+CV-CT-CT    63.0       114.0     jtr: HIE CA-CB-CG
+CX-CT-CT    63.0       114.0     jtr: HIP CA-CB-CG
+CM-CT-HC     35.       109.5
+C=-CT-HC     35.       109.5      wlj
+CT-CT-CT     58.35     112.7      CHARMM 22 parameter file
+CF-CF-CF     58.35     112.7      wlj
+C3-CT-C3     40.       109.5
+C2-CT-C2     40.       109.5
+C2-CT-C3     40.       109.5
+C3-CT-C     63.        109.5    from CA-CT-CT 
+CT-CT-HC     37.5      110.7      CHARMM 22 parameter file
+CT-HC-DM     37.5      109.47     wlj
+CT-HC-HC      0.        37.0      wlj
+DM-HC-HC      0.       109.47     wlj
+CT-OS-DM    10.0       109.47     wlj
+CA-OS-DM    10.0       109.47     wlj
+CT-OH-DM    10.0       109.47     wlj
+CA-OH-DM    10.0       109.47     wlj
+OH-HO-DM    10.0       109.47     wlj
+HO-OH-DM    10.0       109.47     wlj
+CT-S -DM    10.0       109.47     wlj
+CT-SH-DM    10.0       109.47     wlj
+SH-HS-DM    10.0       109.47     wlj
+NZ-CZ-DM    10.0       90.0       wlj
+CA-NT-DM    10.0       109.5      wlj
+NO-ON-DM    10.0       109.5      wlj
+C -N -DM    10.0       109.5      wlj
+DM-ON-DM    10.0       109.5      wlj
+DM-NT-H     10.0       100.       wlj
+DM-N -H     10.0       100.       wlj
+DM-N3-CT    10.0       100.       wlj
+DM-N3-CA    10.0       100.       wlj
+DM-N3-CR    10.0       100.       wlj
+CR-OS-DM    10.0       125.       wlj
+CW-OS-DM    10.0       125.       wlj
+CB-OS-DM    10.0       125.       wlj
+NB-OS-DM    10.0       125.       wlj
+NB-NB-DM    10.0       125.       wlj
+CR-NB-DM    10.0       125.       wlj
+NA-NB-DM    10.0       125.       wlj
+CW-S -DM    10.0       130.       wlj
+NB-S -DM    10.0       130.       wlj
+CR-S -DM    10.0       130.       wlj
+CT-CT-N     80.0       109.7      ALA    JACS 94, 2657
+CT-CT-NM    80.0       109.7      ALA    JACS 94, 2657
+CT-CT-N*     50.       109.5
+CT-CO-N*     50.       109.5      jtr (12/7/01)
+CT-CT-N2    80.0       111.2      ARG   JCP 76, 1439
+C -CT-N3    80.0       111.2      Amino terminal residues
+C -CT-NT    80.0       111.2      wlj
+CA-CT-NT    80.0       111.2      wlj
+CA-CT-NA    80.0       111.2      wlj
+CT-CT-N3    80.0       111.2      LYS(OL)   JCP 76, 1439
+CT-CT-OH     50.       109.5
+CA-CT-OH     50.       109.5      wlj
+CT-CT-OS     50.       109.5
+CA-CT-OS     50.       109.5
+CT-CT-S     50.        114.7      CYX            SCHERAGA  JPC 79,1428
+CT-CT-SH    50.0       108.6      CYS
+CA-CT-S     50.        114.7      wlj
+CW-CT-S     50.        114.7      wlj
+NT-NT-H     35.0       106.0      wlj 1/14
+CT-NT-H     35.0       109.5
+CA-NT-H     35.0       116.0     wlj    anilines 9/06
+CA-NT-CA    50.0       116.0     wlj    anilines 9/06
+CA-NT-CT    50.0       116.0     wlj    anilines 9/06
+CP-NT-H     35.0       116.0     JT-R 2014/04 aminothiophenes, from wlj    anilines 9/06
+CP-NT-CT    50.0       116.0     JT-R 2014/04 aminothiophenes, from wlj    anilines 9/06
+CT-NT-CT    51.8       107.2     wlj - MM3 based JACS 112, 8314 (90)
+CT-NT-CH    51.8       107.2             "
+CT-NT-C2    51.8       107.2             "
+CT-NT-C3    51.8       107.2             "
+CH-NT-CH    51.8       107.2             "
+CH-NT-C2    51.8       107.2             "
+CH-NT-C3    51.8       107.2             "
+C2-NT-C2    51.8       107.2             "
+C2-NT-C3    51.8       107.2             "
+C3-NT-C3    51.8       107.2             "
+HC-CT-HC     33.       107.8      CHARMM 22 
+DM-CM-HC     10.        90.0      wlj
+DM-C=-HC     10.        90.0      wlj
+DM-CM-CM      2.        90.0      wlj
+DM-CZ-CZ      5.        90.0      wlj
+DM-CZ-CA      5.        90.0      wlj
+DM-CZ-HC      5.        90.0      wlj
+DM-CM-C=      2.        90.0      wlj
+DM-C=-C=      2.        90.0      wlj
+DM-C=-CM      2.        90.0      wlj
+DM-DM-DM     33.       109.47     wlj
+DM-HC-DM     33.       109.47     wlj
+DM-HA-DM     33.       109.47     wlj
+DM-HO-DM     33.       109.47     wlj
+DM-HS-DM     33.       109.47     wlj
+DM-H -DM     33.       109.47     wlj
+DM-OS-DM      5.       109.47     wlj
+DM-OH-DM      5.       109.47     wlj
+DM-S -DM      5.       109.47     wlj
+DM-SH-DM      5.       109.47     wlj
+DM-F -DM     33.       109.47     wlj
+DM-Cl-DM     33.       109.47     wlj
+DM-Br-DM     33.       109.47     wlj
+DM-I -DM     33.       109.47     wlj
+CY-CY-HC    37.5       117.2      cyclopropanes - wlj  10/97
+YC-CY-CY    30.0        79.2            "
+CY-CY-CY    30.0        83.0            "
+CY-CY-CT    37.5       117.2            "
+CY-CY-CA    37.5       121.3            "
+CY-CY-CP    37.5       121.3            "
+CY-CT-HC    37.5       110.7            "
+HC-CY-HC     35.       114.3            "
+HC-CY-CT     35.       114.3            "
+CT-CY-CT     35.       114.3            "
+HC-CY-CA     35.       114.0            "
+HC-CY-CP     35.       114.0            "
+CA-CA-CY     70.       120.7            "
+CY-CM-HC     35.       135.0      wlj
+CY-CY-N$     80.        89.0      small rings - wlj
+CY-N$-C$     50.        94.0            "
+N$-C$-CY     70.        91.0            "
+CY-CY-C$     63.        85.0            "
+N$-C$-O      80.       134.0            "
+CY-C$-O      80.       134.0            "
+HC-CY-N$     35.       111.0            "
+HC-CY-N      35.       108.0            "
+HC-CY-C$    37.5       110.0            "
+CY-CY-N     37.5       126.0            "
+HC-CY-S     37.5       108.0            "
+CY-CY-S      55.       128.0            "
+CY-N -C      55.       128.0            "
+CY-N -H      40.       113.0            "
+N -CY-C$     70.       117.0            "
+N$-CY-S      55.       109.0            "
+C$-N$-CT     55.       127.0            "
+CY-S -CT     62.        94.0            "
+CY-N$-CT     50.       126.0            "
+N$-CT-CT     80.       110.0            "
+N$-CT-HC     35.       109.5            "
+N$-CT-C      80.       113.0            "
+CY-O$-CY     60.        90.0            "
+CY-CY-O$     50.        90.0            "
+CT-CY-O$    37.5       117.2            "
+HC-CY-O$    37.5       117.2            "
+HC-CT-N      35.       109.5
+HC-CT-NM     35.       109.5
+HC-CT-N*     35.       109.5      jtr (12/7/01)
+HC-CO-N*     35.       109.5
+HC-CT-NA     35.       109.5      copy from above for CytH+ (jtr 5-14-91)
+HC-CT-N2     35.       109.5
+HC-CT-N3     35.       109.5
+HC-CT-NT     35.       109.5      JACS 115, 9620 (93)
+DM-H -NT     10.       109.5      wlj
+HC-CT-NC     35.       109.5
+HC-CT-OH     35.       109.5
+HC-CT-OS    35.0       109.5      SUG
+HC-CT-S      35.       109.5
+HC-CT-P      41.       109.5      wlj 11/95 MM3 based JACS 114, 8536 (92)
+CT-CT-P      43.       109.5             "
+CA-CT-P      43.       109.5             "
+CT-CT-P+     43.       109.5      wlj 9/97
+CT-P+-CT     45.       109.5      " AMBER OS-P-OS
+HC-CT-P+     41.       109.5      "
+HC-CT-SH     35.       109.5
+N*-CT-OS     50.       109.5
+N*-CO-OS     50.       109.5     jtr (12/7/01)
+CW-CW-NB    70.        120.0 
+HA-CV-NB     35.       121.7     wlj 6/13
+C!-CV-NB     35.       121.7     wlj 6/13
+H4-CW-NA     35.       120.0
+HA-CA-NA     35.       120.0
+HA-CM-NA     35.       120.0
+C -N -C2    50.        121.9      PRO(OL)
+C -N -C3    50.        121.9      TEST!!!!!!!!
+C -N -CH    50.        121.9      AA(OL)
+C -N -CT    50.        121.9
+C -NM-CT    50.        121.9
+C -N -CA    50.        121.9      wlj
+CA-N2-CA    50.        121.9      wlj
+C -N -H     35.        119.8      AA(OL)
+CQ-NC-DM     5.        119.8      wlj    
+C2-N -C3    50.        121.9
+C -N -H2    35.        120.       GLN,ASN                 **
+C2-N -CH    50.        118.       PRO(OL)         DETAR JACS 99,1232
+C2-N -H     38.        118.4      AA(OL)
+C3-N -H     38.        118.4      TEST!!!!!!!
+CH-N -H     38.        118.4      AA(OL)
+CT-N -CT    50.        118.       PRO(OL)         DETAR JACS 99,1232
+CT-N2-CT    50.        118.       
+CT-NM-CT    50.        118.       PRO(OL)
+CA-N -CT    50.        118.       wlj
+CA-NC-CT    50.        118.       wlj
+CT-N -H     38.        118.4
+H -N -H     35.        120.       ADE,CYT,GUA,GLN,ASN     **
+########                          H -N2-H     35.        113.       wlj 
+H -N2-H     35.        120.      MKD MP2(full)/aug-ccpVTZ  - aminoimidazol, changed from 113.0
+H3-N -H3    35.        120.       ADE,CYT,GUA,GLN,ASN     **
+C -N*-CH    70.        117.6      URA,CYT
+C -N*-CJ    70.        121.6      URA,CYT
+C -N*-CM    70.        121.6      
+C -NA-CM    70.        121.6      copy from above for CytH+ (jtr 5-14-91)
+C -N*-CT     70.       117.6
+C -N*-CO     70.       117.6      jtr 12/11/01
+C -N*-H     35.        119.2
+C3-N*-CB    70.        125.8      9 methylated guan,aden
+C3-N*-CE    70.        128.8      Methylated purines
+C3-N*-CK    70.        128.8
+CB-N*-CE    70.        105.4      GUA,ADE
+CB-N*-CH    70.        125.8      GUA,ADE
+CE-N*-CH    70.        128.8      GUA,ADE
+CE-N*-CT     70.       128.8
+CE-N*-H     35.        127.3
+CH-N*-CJ    70.        121.2      URA,CYT
+CH-N*-CK    70.        128.8
+CJ-N*-CT     70.       121.2
+CJ-N*-H     35.        119.2
+CM-N*-CT     70.       121.2
+CM-N*-CO     70.       121.2       jtr 12/11/01
+CM-N*-H     35.        119.2
+CM-NA-H     35.        119.2       copy from above for CytH+ (jtr 5-14-91)
+C2-N2-CA    50.        123.2       ARG(OL)
+C2-N2-H2    35.        118.4      ARG(OL)
+C2-N2-H3    35.        118.4      ARG(OL)
+C3-N2-CA    50.        123.2       ARG(OL)
+C3-N2-H2    35.        118.4      ARG(OL)
+CA-N2-CT    50.        123.2       ARG(OL)
+CA-N2-H     35.        120.       ARG(OL)
+CQ-N2-H     35.        120.       wlj
+CA-N2-H2    35.        120.       ADE,CYT,GUA,ARG
+CA-N2-H3    35.        120.       ADE,CYT,GUA,ARG
+CT-N2-H3    35.        118.4      ARG(OL)
+CT-N2-H     35.        118.4
+H2-N2-H2    35.        120.       ADE,CYT,GUA,GLN,ASN,ARG
+H3-N2-H3    35.        120.       ADE,CYT,GUA,GLN,ASN,ARG
+C2-N3-H3    35.        109.5      LYS
+C3-N3-H3    35.        109.5
+CT-N3-H3    35.        109.5      LYS
+H3-N3-H3    35.        109.5      LYS
+CT-N3-CT    50.        113.0      proline j.phys chem 1979 p 2361
+CA-N3-CT    55.        114.0      wlj                              
+C -NA-C     70.        126.4      URA
+C -N -C     70.        126.4      wlj
+C -NA-CA    70.        125.2      GUA
+C -N -CQ    70.        125.2      wlj
+C -NA-H     35.        116.8      GUA,URA(2)
+CA-NA-H     35.        118.0      GUA
+CQ-N -H     35.        118.0      wlj
+CG-NA-CN    70.        111.6      TRP(OL)
+CG-NA-CR    70.        107.3      HIS(OL)
+CG-NA-H     35.        126.35      HIS(OL)
+CN-NA-CW    70.        111.6      TRP(OL)
+CN-NA-H     35.        123.1       TRP
+CR-NA-H     35.        124.00      HIS(OL)
+CW-NA-H     35.        124.00      JT-R 2014/04  changed back from 129.2       wlj 6/13
+CX-NA-H     35.        124.00      jtr HIP
+CW-NA-CT    70.        124.00      wlj    
+CB-N*-CK    70.        105.4
+CB-N*-CT    70.        125.8
+CB-N*-CO    70.        125.8       jtr (12/7/01)
+CB-N*-H     30.        125.8
+CK-N*-CT    70.        128.8
+CK-N*-CO    70.        128.8       jtr (12/7/01)
+CK-N*-H     30.        128.8
+CB-NA-CK    70.        105.4       wlj
+CB-NA-CT    70.        125.8       wlj
+CB-NA-H     30.        125.8       wlj
+CK-NA-CT    70.        128.8       wlj
+CK-NA-H     30.        128.8       wlj
+CB-NB-CE    70.        103.8      GUA,ADE
+CB-NB-CK    70.        103.8
+CR-NB-CV    70.        110.0      HIS(OL) wlj 1/97
+CR-NB-CB    70.        110.0      wlj
+CR-NB-CW    70.        110.0
+C -NC-CA    70.        120.5      CYT
+C -NC-C=    70.        120.5      CYT
+C -NC-CT    70.        120.5      imine - check
+C -N=-C=    70.        120.5      imine - check
+CA-NC-CB    70.        112.2      GUA
+CA-NC-CI    70.        118.6      ADE
+CA-NC-CQ    70.        118.6
+CQ-NC-CQ    70.        118.6      wlj 1,3,5-triazine
+CB-NC-CI    70.        111.0      ADE
+CB-NC-CQ    70.        111.0
+CR-NC-CQ    70.        111.0      wlj
+C2-NT-H     43.2       108.1      wlj MM3 based
+C3-NT-H     43.2       108.1      wlj MM3 based
+CH-NT-H     43.2       108.1      wlj MM3 based
+H -NT-H     43.6       106.4      wlj MM3 based           
+H -N3-H     43.6       109.5      wlj            
+H -N -OH    35.        110.2      wlj
+C -N -OH    46.        115.7      wlj
+N -OH-HO    49.        105.4      wlj
+C -OH-HO    35.        113.0      TYR(PHENOL)     HARMONY MEOH
+CA-OH-HO    35.        113.0
+CP-OH-HO    35.        109.0     JT-R 2014/04 hydroxy thiophene
+C -O -DM    35.        113.0
+DM-O -DM    10.        117.0
+CM-OH-HO    35.        109.0      wlj
+C2-OH-HO    55.0       108.5      SUG,SER(OL,mod)
+C3-OH-HO    55.0       108.5      SUG,SER(OL,mod)
+CH-OH-HO    55.0       108.5      THR(OL),SUG
+CT-OH-HO     55.       108.5      
+HO-OH-P     55.0       108.5      SUG(OL)
+C2-OS-C2    100.0      111.8       DME based
+C2-OS-C3    100.0      111.8       DME based
+CH-C -OS    81.        111.4    from FK506, SKF8
+C -OS-CH    83.        116.9    from FK506 C -OS-CZ for SKF8
+C -OS-C2    83.        116.9
+C -OS-C3    83.        116.9
+O -C -OS    83.        123.4    J.Comp.Chem.1990,11,1181 for SKF8
+C -OS-CT    83.        116.9       "
+OS-C -CT    81.        111.4       "
+OS-C -CA    81.        111.4      wlj
+C -OS-CA    83.        116.9      wlj
+CA-CH-OS    80.0       109.5    SUG from AMBER/BOSS for SKF8
+OS-CO-OH     92.6      111.55   Ha,CarbRes 180,207(88)Merz,JCC 15,1019 (94)
+OS-CO-OS     92.6      111.55     ACETAL - wlj 2/93
+C3-OS-CO    100.0      113.0        "
+C2-OS-CO    100.0      113.0        "
+CH-OS-CO    100.0      113.0        "
+C2-CO-OS    80.0       109.5        "
+C3-CO-OS    80.0       109.5        "
+C3-CO-C3    40.0       109.5        "
+C2-C2-CO    63.0       112.4        "
+C3-C2-CO    63.0       112.4        "
+OS-CO-CT    50.        109.5       hexopyranoses :  CT-CT-OS - wd 3/95 Glucose
+CO-CT-CT    58.35      112.7        "            :  CT-CT-CT - wd 6/95 Glucose
+CT-CO-OH    50.        109.5        "            :  CT-CT-OH - wd 6/95 Glucose
+CT-CO-HC    37.5       110.7        "            :  CT-CT-HC - wd 6/95 Glucose
+CO-OH-HO    55.        108.5        "            :  CT-OH-HO - wd 6/95 Glucose
+OS-CO-HC    35.0       109.5        "            :  HC-CT-OS - wd 6/95 Glucose
+CO-OS-CT    60.        109.5        "            :  CT-OS-CT - wd 6/95 Glucose
+CO-CT-HC    37.5       110.7        "            :  CT-CT-HC - wd 6/95 Glucose
+CO-CT-OH    50.        109.5        "            :  CT-CT-OH - wd 6/95 Glucose
+OH-CO-HC    35.0       109.5        "            :  HC-CT-OS - wd 6/95 Glucose
+HC-CO-HC    33.        109.5        "            :  HC-CT-HC - wd 6/95
+C2-OS-HO    55.0       108.5      SUG
+CA-OS-P     100.0      120.5      mll
+C2-OS-P     100.0      120.5      SUG(OL)
+C3-OS-P     100.0      120.5     DMPhos based
+CH-OS-CH    100.0      111.8      SUG(dme based)
+CH-OS-HO    55.0       108.5      SUG
+CH-OS-P     100.0      120.5      SUG
+CT-OS-CT     60.       109.5
+Si-OS-Si     20.       145.0      wlj
+CT-OS-Si     40.       121.0      wlj
+Si-OH-HO     40.       117.0      wlj
+CT-Si-OS     60.       105.0      wlj
+CT-Si-OH     60.       107.0      wlj
+CT-Si-CT     37.       112.5      wlj fit to expt
+CT-CT-Si     40.       114.0      wlj fit to expt
+CA-Si-CT     40.       112.5      wlj
+CA-CA-Si     45.       121.0      wlj
+CT-Si-Si     40.       112.0      wlj
+H -Si-Si     25.       110.5      wlj
+OS-Si-OS     60.       110.0      wlj
+Si-CT-HC     35.       110.9      wlj fit to expt
+H -Si-H      33.       109.0      wlj fit to expt
+H -Si-CT     28.       110.5      wlj fit to expt
+H -Si-OH     35.       111.0      wlj
+H -Si-OS     35.       111.0      wlj
+H -Si-CA     30.       110.0      wlj
+F -Si-CT     35.       110.5      wlj
+Cl-Si-CT     35.       110.5      wlj
+Br-Si-CT     35.       110.5      wlj
+I -Si-CT     35.       110.5      wlj
+CT-OS-CA     75.       111.0      wlj 9/97
+CA-OS-CA     75.       116.3    MKD MP2(full)/6-311G(d,p) - biaryl ethers, changed from 111.0
+CT-OS-CM     75.       111.0      wlj
+CT-OS-P     100.       120.5
+CT-OH-P     100.       120.5      jtr 12/10/01
+O -C -O2     80.       126.0      adk
+O2-P -O2    140.0      119.9      SUG(OL)
+O2-P -OH    45.0       108.23     SUG(OL)
+O2-P -OS    100.0      108.23     SUG(OL)
+OH-P -OS    45.0       102.6      SUG(OL)
+OS-P -OS    45.0       102.6      SUG(OL)
+O -P -OH    100.0      108.23     SUG(OL)
+O -P -OS    100.0      108.23     SUG(OL)
+OH-P -OH    45.0       102.6      SUG(OL)
+CT-P -OS    45.0       109.5      wlj 11/95
+CT-P -O2    45.0       109.5      wlj 11/95
+CT-P -O     45.0       109.5      wlj 11/95
+CA-P -OS    45.0       109.5      wlj 11/95
+CA-P -OH    45.0       109.5      wlj 11/95
+CA-P -O     45.0       109.5      wlj 11/95
+C2-S -C3    62.         98.9       MET(OL)
+C2-S -LP    150.        96.7
+C2-S -S     68.        103.7       CYX(OL)        SCHERAGA  JPC 79,1428
+C3-S -LP    150.        96.7
+C3-S -S     68.        103.7       CYX(OL)        SCHERAGA  JPC 79,1428
+CT-S -CT    62.         98.9       MET(OL)
+CR-S -CW    74.         90.0       wlj
+CW-S -CW    74.         97.0       wlj
+CB-S -CB    74.         97.0       wlj
+CB-S -N     74.         92.4       wlj
+CR-S -CB    74.         97.0       wlj
+CW-S -CB    74.         97.0       wlj
+CT-S -LP    150.        96.7
+CT-S -S     68.        103.7       CYX(OL)        SCHERAGA  JPC 79,1428
+LP-S -LP     10.       160.0
+LP-S -S     150.        96.7
+C2-SH-HS    44.         96.0        CYS(OL)
+C2-SH-LP    150.        96.7
+C3-SH-HS    44.         96.0        CYS(OL)
+C3-SH-LP    150.        96.7
+CT-SH-HS    44.         96.0        CYS(OL)
+CA-SH-HS    50.         96.0        wlj
+CT-SH-LP    150.        96.7
+HS-SH-HS     35.        92.07
+HS-SH-LP    150.        96.7
+LP-SH-LP     10.       160.0
+P -OS-P     100.       120.5
+C9-C8-C8    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-C8    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-C8    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-C8    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C8-CT    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C8-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C8-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C8-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C8-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C8-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C8-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C8-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C8-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C3-C8-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C7-CT    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C7-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C7-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C7-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C7-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C7-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C7-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C7-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C7-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C3-C7-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CA-OS-C2   100.0       111.8    AMBER(MMOD) 9/9/91
+CA-CT-CA    40.0       109.5      "
+CA-CT-C2    63.0       114.0      "           
+CA-CT-C     63.0       112.0    wlj
+N -CT-C2    80.        109.7    Added DSM (from N -CT-C3)
+HC-CT-C2    35.        109.5    Added DSM (from C -CT-HC)
+C -CT-C2    63.        111.1    Added DSM (from C3-CT-C )
+CT-CA-NA    70.        120.00   Added DSM (from CT-CC-NA)
+CA-NA-CA    70.        125.2    Added DSM (from C -NA-CA)
+CA-CA-NB    70.        108.7    Added DSM (from CA-CA-NA)
+NA-CA-NB    70.        123.3    Added DSM (from NA-CA-NC)
+CA-NB-CA    70.        125.2    Added DSM (from C -NA-CA)
+HA-CA-NB     35.       119.1    Added DSM (from HC-CM-NA)
+CA-CA-N     70.        120.0    Added DSM (from CA-CA-NA)
+CA-N -H     35.        119.8    Added DSM (from C -N -H)
+CU-N -H     35.        119.8    wlj                         
+CW-N -H     35.        119.8    wlj                         
+CS-N -H     35.        119.8    wlj                         
+CB-CT-HC     35.       109.5    Added DSM (from CA-CT-HC)
+CA-CB-CT    70.        120.     Added DSM (from CA-CA-CT)
+CB-CA-NA    70.        108.7    Added DSM (from CA-CA-NA)
+CB-CB-CT    70.        120.     Added DSM (from CA-CA-CT)
+CB-CT-CT    63.        114.     Added DSM (from CA-CT-CT)
+CT-CT-F     50.        109.5    PAK F-CT-HC (emd 5-09-94)
+CF-CF-F     50.        109.5    wlj
+C2-C2-F     50.        109.5
+CA-CT-F     50.        109.5    wlj 
+CA-CF-F     50.        109.5    wlj 
+CM-CT-F     50.        109.5    wlj 
+F -CT-F     77.        109.1    PAK F-CT-F  (emd 5-09-94)
+F -CF-F     77.        109.1    wlj                        
+HC-CT-F     40.        107.0    wlj
+CT-C -C     80.        117.2    (JP 1-6-91)  SKF8
+C -C -O     80.        121.4    ketone (JP 1-5-91) SKF8
+C -C -N     70.        116.6    (JP 1-5-91) SKF8
+C9-C8-SY    70.        118.
+C8-SY-C3    62.        98.9
+OY-SY-N    120.0      107.0
+OY-SY-OY   104.0      123.0      wlj 9/19 from MeSO2F
+OY-SY-OH    74.0      108.7
+SY-OH-HO    74.0      110.0 
+OY-SZ-CT    74.0      107.0
+N -SY-CA   100.       103.0
+SY-CA-CA    85.       119.4
+SY-CT-HC    35.0      109.5
+SZ-CT-HC    35.0      109.5
+CT-SY-CT    62.0      102.0       
+CA-SY-CT    62.0      102.0
+CR-SY-CT    62.0      102.0
+CT-SZ-CT    62.0       96.0
+CT-CT-SY    50.0      108.6
+CT-CT-SZ    50.0      108.6
+OH-SY-CT    75.0       96.4
+OH-SY-CA    75.0       96.4
+N -SY-CT   100.0      103.0
+SY-N -CT    50.       120.0
+H -N -SY   100.0      111.0
+OS-C -N     81.        111.4    bhap,                   copy from OS-C -CT      rcr HIVRT
+CT-NT-SY    50.0      108.6     bhap,                   copy from CT-CT-SY      rcr HIVRT
+C -CT-F     50.        109.5    bhap,                   copy from CT-CT-F       rcr HIVRT
+SY-CT-F     50.        109.5    bhap,                   copy from CT-CT-F       rcr HIVRT
+SY-NT-H     35.0       115.0    bhap,                   adjusted from CT-NT-H   rcr HIVRT
+C -CW-NA    85.        120.     bhap,                   copy from C -CA-CA      rcr HIVRT
+NT-C -CW    70.        116.0    bhap,                   copy from CT-C -CT      rcr HIVRT
+C -CW-CS    85.        120.     bhap,                   copy from C -CA-CA      rcr HIVRT
+CB-CS-HA     35.       120.0    bhap,                   copy from CB-CA-HA      rcr HIVRT
+CW-C -O     80.        120.4    bhap,                   copy from CA-C -O       rcr HIVRT
+C -NT-CT    63.0       111.1    bhap,                   copy from C -CT-CT      rcr HIVRT
+C -CT-C     63.0       111.1    lac,                    copy from C -CT-CT      rcr HIVRT
+C -CT-OS     50.       109.5    lac,                    copy from CT-CT-OS      rcr HIVRT
+N -CT-OS     50.       109.5    lac,                    copy from CT-CT-OS      rcr HIVRT
+NT-C -O     80.        120.4    nev,                    copy from CT-C -O       rcr HIVRT
+NT-C -CT    70.        116.0    nev,                    copy from CT-C -CT      rcr HIVRT
+CA-NT-C     63.0       112.0    nev,                    copy from CA-CT-C       rcr HIVRT
+CA-NT-SY    50.0      108.6     nev,                    copy from CT-CT-SY      rcr HIVRT
+OY-SY-NT    74.0      108.9     nev,                    copy from OY-SY-CT      rcr HIVRT
+NT-SY-CT    62.0      102.0     nev,                    copy from CT-SY-CT      rcr HIVRT
+NT-CT-S     50.        114.7    nev,                    copy from CT-CT-S       rcr HIVRT
+HC-CY-NT     35.       114.3    nev,                    copy from HC-CY-CT      rcr HIVRT
+CY-CY-NT    37.5       117.2    nev,                    copy from CY-CY-CT      rcr HIVRT
+CA-NT-CY    50.        109.5    nev,                    copy from CA-NT-CT      rcr HIVRT
+NC-CA-Cl    75.        120.0    nev,                    copy from CA-CA-Cl      rcr HIVRT
+NC-CA-NT     70.       116.0    nev,                    copy from NC-CA-CT      rcr HIVRT
+CM-CM-CY     70.       124.0    hept,                   copy from CM-CM-CT      rcr HIVRT
+CM-CY-HC     35.       109.5    hept,                   copy from CM-CT-HC      rcr HIVRT
+CM-CY-CY    63.        114.     hept,                   copy from CA-CT-CT      rcr HIVRT
+C -CM-CY     70.       119.7    hept,                   copy from C -CM-CT      rcr HIVRT
+N*-CM-CT    70.        120.     hept,                   copy from PHE(OL)       rcr HIVRT
+NA-CM-CT    70.        120.     hept,                   copy from PHE(OL)       rcr HIVRT
+S -CM-CM    85.        119.4    hept,                   copy from SY-CA-CA      rcr HIVRT
+S -CM-N*    85.        119.4    hept,                   copy from SY-CA-CA      rcr HIVRT
+S -CM-NA    85.        119.4    hept,                   copy from SY-CA-CA      rcr HIVRT
+N*-CM-OS    70.        120.     hept,                   copy from CA-CA-OS      rcr HIVRT
+NA-CM-OS    70.        120.     hept,                   copy from CA-CA-OS      rcr HIVRT
+CA-S -CM    62.        104.2    hept,                   adjusted from CT-S -CT  rcr HIVRT
+CM-OS-CA    75.        111.0    hept,                   copy from CT-S -CT      rcr HIVRT
+CM-CT-CA    40.0       109.5    hept,                   copy from CA-CT-CA      rcr HIVRT
+S -CA-CA    85.        119.4    thioanisole             copy from SY-CA-CA      rcr HIVRT
+P -CA-CA    85.        119.4    
+CA-S -CT    65.         97.0    thioanisole JT-R 2014/04 MP2/cc-pVTZ (was 62,104.2 adj. rcr HIVRT)
+CZ-S -CT    65.        100.0    wlj 9/06 
+C -N -Zn    20.        126.                             Merz, JACS 113, 8262 (1991)
+HO-OH-Zn   100.        126.
+N -Zn-N     20.        109.5
+N -Zn-O     20.        109.5
+SA-CP-CY    70.        121.1    JT-R 2014/04 cyclopropyl thiophene MP2/aug-cc-pVTZ
+CS-CP-CY    70.        128.4    JT-R 2014/04 cyclopropyl thiophene MP2/aug-cc-pVTZ
+SA-CP-NT    70.        120.8    JT-R 2014/04 amino thiophene MP2/aug-cc-pVTZ
+CS-CP-NT    70.        128.6    JT-R 2014/04 amino thiophene MP2/aug-cc-pVTZ
+SA-CP-CS    70.        111.0    MKD New Thiophene MP2(full)/6-311G(d,p)
+SA-CP-HA    35.        120.0    MKD New Thiophene MP2(full)/6-311G(d,p)
+CS-CP-HA    35.        128.2    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-CS-HA    35.        123.1    MKD New Thiophene MP2(full)/6-311G(d,p)
+CS-CS-CP    70.        112.3    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-C!-CA    63.        120.5    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-C!-NC    63.        116.8    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-C!-NA    63.        117.2    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-C!-C=    63.        123.8    MKD New Thiophene MP2(full)/6-311G(d,p)   
+SA-CP-C!    63.        121.7    MKD New Thiophene MP2(full)/6-311G(d,p)
+CS-CP-C!    63.        127.7    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-CS-C!    63.        123.6    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-SA-CP    70.         92.2    MKD New Thiophene MP2(full)/6-311G(d,p)
+NC-C!-NC    70.        126.3    MKD MP2(full)/6-311G(d,p) new
+C!-CR-NA    70.        123.1    MKD MP2(full)/6-311G(d,p) new
+CR-C!-NC    70.        116.6    MKD MP2(full)/6-311G(d,p) new
+CV-C!-NC    70.        116.6    wlj 6/13                       
+CW-C!-NC    70.        117.1    MKD MP2(full)/6-311G(d,p) new
+C=-C!-NA    70.        119.6    MKD MP2(full)/6-311G(d,p) new
+C -NA-C!    70.        126.6    MKD MP2(full)/6-311G(d,p) new
+C!-NA-H     35.        118.0    MKD MP2(full)/6-311G(d,p) new
+C=-CM-C     85.        121.7    MKD MP2(full)/6-311G(d,p) new
+HC-C=-C!    35.        119.9    MKD MP2(full)/6-311G(d,p) new
+CW-C!-NA    70.        116.4    MKD MP2(full)/6-311G(d,p) new
+C=-C!-CW    63.        124.7    MKD MP2(full)/6-311G(d,p) new
+C!-C=-C=    70.        118.1    MKD MP2(full)/6-311G(d,p) new
+CS-C!-NC    63.        117.0    MKD MP2(full)/6-311G(d,p) new
+C!-NA-CW    63.        125.2    MKD MP2(full)/6-311G(d,p) new
+NA-C!-NC    63.        116.2    MKD MP2(full)/6-311G(d,p) new
+CS-C!-NA    63.        116.8    MKD MP2(full)/6-311G(d,p) new
+C=-C!-CS    63.        124.2    MKD MP2(full)/6-311G(d,p) new
+C!-C!-NA    63.        116.6    MKD MP2(full)/6-311G(d,p) new
+C=-C!-C!    63.        123.9    MKD MP2(full)/6-311G(d,p) new
+CR-C!-NA    63.        114.3    MKD MP2(full)/6-311G(d,p) new
+C=-C!-CR    63.        126.0    MKD MP2(full)/6-311G(d,p) new
+NA-C!-CA    63.        119.8    MKD MP2(full)/6-311G(d,p) new
+C!-NA-NB    63.        119.9    MKD MP2(full)/6-311G(d,p) new
+NA-C!-NA    63.        115.7    MKD MP2(full)/6-311G(d,p) new only give NA-C!-NX in paper?
+NX-C!-NC    63.        116.2    MKD synonym for NA-C!-NC  
+NX-CW-HA    35.        121.6    MKD synonym for HA-CW-NA
+NX-CW-CS    70.        107.7    MKD synonym for NA-CW-CS
+CW-NX-C!    63.        125.2    MKD synonym for C!-NA-CW
+CW-NX-CW    70.        109.8    MKD synonym for CW-NA-CW
+NX-C!-CA    63.        119.8    MKD synonym for NA-C!-CA
+C!-NX-NB    63.        119.9    MKD synonym for C!-NA-NB   
+NB-NX-CW    56.        113.1    MKD synonym for NB-NA-CW
+NX-C!-NA    63.        115.7    MKD synonym for NA-C!-NA
+C=-C!-NX    63.        123.8    MKD MP2(full)/6-311G(d,p) - new - external NA connected to pyridone
+HA-CU-CS    35.        129.2    MKD MP2(full)/6-311G(d,p) - new pyrazole
+CU-NB-NX    70.        104.1    MKD synonym for CU-NB-NA
+HA-CS-CU    35.        128.5    MKD MP2(full)/6-311G(d,p) - new pyrazole
+N2-CR-NA    70.        126.65   MKD MP2(full)/aug-ccpVTZ  - aminoimidazol
+H -N2-CR    35.        120.     MKD MP2(full)/aug-ccpVTZ  - aminoimidazol
+NE-C -NE    70.        105.8    MKD MP2(full)/6-311G(d,p) - hydantoin
+O -C -NE    70.        127.5    MKD MP2(full)/6-311G(d,p) - hydantoin
+CT-NE-C     70.        112.5    MKD MP2(full)/6-311G(d,p) - hydantoin
+C -CT-NE    70.        102.8    MKD MP2(full)/6-311G(d,p) - hydantoin
+HC-CT-NE    35.        109.5    MKD MP2(full)/6-311G(d,p) - hydantoin
+C!-NE-C     63.        124.0    MKD MP2(full)/6-311G(d,p) - hydantoin
+CA-C!-NE    63.        120.0    MKD 
+CT-NE-CT    70.        123.2    MKD MP2(full)/6-311G(d,p) - hydantoin
+C -NE-C     70.        112.1    MKD MP2(full)/6-311G(d,p) - hydantoin
+CT-C -NE    70.        105.8    MKD MP2(full)/6-311G(d,p) - hydantoin
+H -NE-C     35.        112.5    MKD MP2(full)/6-311G(d,p) - hydantoin
+H -NE-CT    35.        123.2    MKD MP2(full)/6-311G(d,p) - hydantoin
+CT-CT-NE    70.        109.5    MKD 
+C!-NC-NC    70.        117.0    MKD synonym for CA-NC-NC
+CQ-NC-NC    70.        118.2    MKD MP2(full)/6-311G(d,p)
+NB-CR-NB    70.        112.2    MKD MP2(full)/6-311++G(d,p) - negatively charged tetrazole
+NB-NB-NB    70.        109.4    MKD MP2(full)/6-311++G(d,p) - negatively charged tetrazole
+N -OS-CB     70.       104.5     "
+NB-OS-CR     70.       101.3       JT-R oxatriazoles
+NB-CR-OS     70.       115.0     "
+NB-CR-S      70.       115.0     "
+CR-OS-CW     70.       104.0     "
+CV-CW-OS     70.       108.0     "
+HA-CR-OA     35.       117.0     "
+OS-CM-HC     35.       114.5
+CB-CA-HA     35.       120.0
+CC-CA-HA     35.       120.0
+CB-CA-N2    70.        123.5    ADE
+CB-CA-NC    70.        117.3    ADE
+CD-CA-CD    85.        120.     PHE(OL)
+CJ-CA-N2    70.        120.1    CYT
+CJ-CA-NC    70.        121.5    CYT
+CM-CA-N2    70.        120.1
+CA-CA-N2    70.        120.1    wlj
+CM-CA-NC    70.        121.5
+C=-CA-NC    70.        121.5
+CM-CA-NA    70.        121.5    copy from above for CytH+ (jtr 5-14-91)
+CN-CA-HA     35.       120.0
+NY-CA-NY    70.        111.8    jtr: neutral ARG
+NC-CA-NY    70.        124.1    jtr: neutral ARG
+CA-NC-H     35.        113.0    jtr: neutral ARG
+CA-NY-H     50.        112.5    jtr: neutral ARG
+CA-NY-CT    50.        120.5    jtr: neutral ARG
+H -NY-H     43.6       106.4    jtr: neutral ARG
+CT-NY-H     35.        109.5    jtr: neutral ARG
+CT-CT-NY    80.0       111.2    jtr: neutral ARG
+HC-CT-NY     35.       109.5    jtr: neutral ARG
+N2-CA-N2    70.        120.       ARG(OL)
+N2-CA-NA    70.        116.0    GUA
+N2-CA-NC    70.        119.3    ADE,GUA
+N2-CQ-NC    70.        119.3    wlj    
+N2-CQ-N     70.        116.0    wlj
+NA-CA-NC    70.        123.3    GUA
+C -CB-CB    85.        119.2    GUA
+C -CB-NB    70.        130.     GUA
+N -CQ-NC    70.        123.3    wlj
+C -CS-CW    70.        130.     wlj
+C -CB-CW    70.        130.     wlj
+C*-CB-CA    85.        134.9     TRP(OL)
+C*-CB-CD    85.        134.9     TRP(OL)
+CA-CB-CA    85.        134.9     TRP(OL)
+C*-CB-CN    85.        108.8     TRP(OL)
+CA-CB-CC    85.        108.8     TRP(OL)
+C*-CB-CC    85.        108.8     TRP(OL)
+CS-CB-CA    85.        134.9     
+CS-CB-CD    85.        134.9     
+CS-CB-CN    85.        108.8     
+CS-CB-CC    85.        108.8     
+CA-CB-CB    85.        117.3    ADE
+C!-CB-CB    85.        117.3    ADE
+CA-CB-CN    85.        116.2     TRP
+CA-CB-NB    70.        132.4    ADE
+CB-CB-N*    70.        106.2    GUA,ADE
+CB-CB-NA    70.        106.2    wlj
+CS-CR-NA    70.        106.2    wlj
+CB-CB-NB    70.        111.0    GUA,ADE
+CR-CS-CW    70.        110.4    wlj
+CB-CB-NC    70.        127.7    GUA,ADE
+CB-CB-N     70.        127.7    wlj
+CS-CR-NC    70.        127.7    wlj
+CD-CB-CN    85.        116.2     TRP
+N*-CB-NC    70.        126.2    GUA,ADE
+NA-CB-NC    70.        126.2    wlj
+NB-CB-N     70.        126.2    wlj
+NB-CR-N     70.        126.2    wlj
+NA-CR-NC    70.        126.2    wlj
+C!-CR-OS    70.        122.0    wlj 12/06
+C!-CR-NB    70.        125.2    MKD MP2(full)/6-311G(d,p) changed from 130.0
+CR-NB-NB    70.        109.0    wlj 12/06
+CV-NB-NB    70.        109.3    wlj 6/13 
+CR-OS-CR    70.        107.0    wlj 12/06
+C2-CC-CF    70.        131.9     HIS(OL)
+C2-CC-CG    70.        129.05    HIS(OL)
+C2-CC-CV    70.        131.9     HIS(OL)
+C2-CC-CW    70.        129.05    HIS(OL)
+C2-CC-NA    70.        122.2     HIS(OL)
+C2-CC-NB    70.        121.05    HIS(OL)
+CF-CC-NA    70.        105.9     HIS(OL)
+CG-CC-NA    70.        108.75    HIS(OL)
+CG-CC-NB    70.        109.9     HIS(OL)
+CT-CC-CV    70.        120.00    HIS(OL)
+CT-CW-CV    70.        130.7     jtr: HID CB-CG-CD2
+CT-CV-CW    70.        130.7     jtr: HIE CB-CG-CD2
+CT-CX-CX    70.        130.7     jtr: HIP CB-CG-CD2
+CT-CW-CW    70.        120.00
+CT-CC-CW    70.        120.00    HIS(OL)
+CT-CC-NA    70.        120.00    HIS(OL)
+CT-CC-NB    70.        120.00    HIS(OL)
+CV-CC-NA    70.        120.00    HIS(OL)
+CW-CW-NA    70.        120.0
+CW-CC-NA    70.        120.00    HIS(OL)
+CW-CC-NB    70.        120.00    HIS(OL)
+C -CD-CD    85.        120.     TYR(OL)
+CA-CD-CD    85.        120.     PHE
+CB-CD-CD    85.        120.      TRP(OL)
+CD-CD-CD    85.        120.     PHE(OL)
+CD-CD-CN    85.        120.     TRP(OL)
+CD-CD-CC    85.        120.     TRP(OL)
+N*-CE-NB    70.        113.9    ADE,GUA
+CC-CF-NB    70.        109.9     HIS(OL)
+C*-CG-NA    70.        108.7     TRP(OL)
+CA-CA-NA    70.        108.7     TRP(OL)
+C*-CC-NA    70.        108.7     TRP(OL)
+CC-CG-NA    70.        105.9     HIS(OL)
+C -CH-C2    63.0       111.1      AA
+C -CH-C3    63.0       111.1      ALA
+C -CH-CH    63.0       111.1      ILE
+C -CH-N     63.0       110.1      AA     WORK DONE ON 6/23/82
+C -CH-NT    80.0       109.7      AA
+C2-CH-CH    63.0       111.5      SUG,ILE
+C2-CH-N     80.0       109.7      ALA    JACS 94, 2657
+C2-CH-N*    80.0       109.5      SUG
+C2-CH-OS    80.0       109.5      SUG
+C3-CH-C3    63.0       111.5      VAL
+C3-CH-CH    63.0       111.5      ILE
+C3-CH-N     80.        109.5                 **
+C3-CH-OH    80.0       109.5      THR
+CH-CH-CH    63.0       111.5      SUG
+CH-CH-N     80.0       109.7      ILE    JACS 94, 2657
+CH-CH-N*    80.0       109.5      SUG
+CH-CH-OH    80.0       109.5      THR,end sugar
+CH-CH-OS    80.0       109.5      SUG
+N*-CH-OS    80.0       109.5      SUG
+NC-CI-NC    70.        129.1    ADE
+C -CJ-CJ    85.        120.7    URA
+CA-CJ-CJ    85.        117.0    CYT
+CJ-CJ-N*    70.        121.2    CYT
+CM-CJ-N*    70.        121.2    THY
+N*-CK-NB    70.        113.9
+NA-CK-NB    70.        113.9      wlj
+NA-CK-H5    35.        123.05
+N*-CK-H5    35.        123.05
+NB-CK-H5    35.        123.05
+C -CM-C3    85.        119.7      THY
+C -CM-CJ    85.        120.7      THY
+C -CM-CM    85.        120.7
+C -CM-CT     70.       119.7
+C -CA-CT     70.       119.7      wlj
+C -CM-HC     35.       119.7
+C -CM-HA     35.       119.7
+C3-CM-CJ    85.        119.7      THY
+CA-CM-CM    85.        117.0
+CA-C=-CM    85.        117.0
+CA-C#-C#    85.        117.0
+CA-CM-HC     35.       123.3
+CP-CM-HC     35.       123.3
+CA-C=-HC     35.       123.3
+CA-C#-HC     35.       123.3
+CJ-CM-CT     85.       119.7
+CM-CM-CT     70.       124.0      wlj
+CM-CM-CZ     70.       124.0      wlj
+C#-C#-CZ     70.       124.0      wlj
+C#-C#-CT     70.       124.0      wlj
+CM-C=-C=     70.       124.0      wlj
+C#-C=-CM     70.       124.0      wlj
+C#-C#-C=     70.       124.0      wlj
+C#-C#-C#     70.       124.0      wlj
+CM-C=-C      70.       118.7      wlj
+CM-C=-CT     70.       124.0      wlj
+C=-C=-CT     70.       124.0      wlj
+C=-C#-CT     70.       124.0      wlj
+C#-C=-CT     70.       124.0      wlj
+CT-CM-C=     70.       124.0      mwm
+CM-CT-CM     63.       112.4      mwm
+CM-CM-HC     35.       120.0      wlj
+C#-C#-HC     35.       120.0      wlj
+CM-CM-H4     35.       119.7
+CM-C=-HC     35.       120.0      wlj
+C=-CM-HC     35.       120.0      wlj
+C=-C=-HC     35.       120.0      wlj
+C=-CM-HA     35.       120.0      wlj
+C=-C=-HA     35.       120.0      wlj
+CM-C=-HA     35.       120.0      wlj
+C!-C=-HA     35.       120.0      wlj
+N=-C=-HC     35.       120.0      wlj imine check
+CZ-C=-HC     35.       120.0      wlj
+CZ-CM-HC     35.       120.0      wlj
+C#-C=-HC     35.       120.0      wlj
+C=-C#-HC     35.       120.0      wlj
+CT-C -HC     35.       115.0      wlj
+HC-C -HC     35.       115.0      wlj check 
+CA-C -HC     35.       115.0      wlj
+CT-CM-HC     35.       117.0      wlj
+HC-CM-HC     35.       117.0      wlj
+CT-CM-CT     70.       130.0      wlj
+CT-C+-CT    172.8      120.0      wlj JACS 94, 4632 (1972)
+CT-C+-HC    144.0      120.0      wlj          "
+CT-CT-C+     63.0      105.0      wlj
+HC-CT-C+     35.0      105.0      wlj
+CM-C=-N=    70.        121.2
+CM-CM-N*    70.        121.2
+CM-CM-NA    70.        121.2      copy from above for CytH+ (jtr 5-14-91)
+HC-CM-N*     35.       119.1
+HC-CM-NA     35.       119.1      copy from above for CytH+ (jtr 5-14-91)
+CA-CN-CB    85.        122.7      TRP
+CA-CN-NA    70.        132.8    TRP(OL)
+CB-CN-CD    85.        122.7      TRP
+CB-CC-CA    85.        122.7      TRP
+CB-CC-CD    85.        122.7      TRP
+CB-CA-CW    63.0       106.4
+CB-CA-CT    70.        128.6
+CB-CN-NA    70.        104.4
+CB-CC-NA    70.        104.4
+CD-CN-NA    70.        132.8    TRP(OL)
+CA-CC-NA    70.        132.8    TRP(OL)
+CD-CC-NA    70.        132.8    TRP(OL)
+NA-CP-NA    70.        110.75    HISP(OL)
+NA-CP-NB    70.        111.6    HIS(OL)
+HA-CQ-NC     35.       115.45
+H5-CQ-NC     35.       115.45
+NC-CQ-NC    70.        129.1
+HA-CR-NA     35.       120.0
+HA-CX-NA     35.       120.0    jtr: HIP HD2-CD2-NE2
+HA-CR-NB     35.       120.0
+HA-CK-N*     35.       120.0
+HA-CK-NA     35.       120.0      wlj
+HA-CK-NB     35.       120.0      wlj
+NA-CR-NA    70.        106.7    MKD MP2(full)/aug-ccpVTZ  - aminoimidazol,HIP
+NA-CR-NB    70.        110.5    MKD MP2(full)/6-311G(d,p) changed from 120.0
+NA-CR-CT    70.        125.0      wlj
+NA-CR-CA    70.        125.0      wlj
+NB-CR-CT    70.        125.0      wlj
+NA-CR-SY    70.        120.       wlj
+NB-CR-SY    70.        120.       wlj
+NB-CR-S     70.        113.6      wlj
+C -CT-CT    63.0       111.1      AA
+CM-CT-CT    63.0       111.1      " wlj
+CW-CT-HC     35.0      109.5    jtr: HID HB-CB-CG
+CP-CT-HC     35.0      109.5    JT-R 2014/04: thiophenes
+CV-CT-HC     35.0      109.5    jtr: HIE HB-CB-CG
+CX-CT-HC     35.0      109.5    jtr: HIP HB-CB-CG
+C -CT-HC     35.       109.5
+C -CT-N     63.0       110.1      AA     WORK DONE ON 6/23/82
+C -CT-NC    63.0       110.1      wlj
+C*-CT-CT    63.0       115.6      TRP(OL)
+C*-CT-HC     35.       109.5
+CS-CT-CT    63.0       115.6    wlj
+CS-CT-HC     35.       109.5    wlj
+CA-CT-CT    63.        114.       PHE(OL)         SCH JPC  79,2379
+CA-CT-HC     35.       109.5
+CA-N3-H3     35.       109.5    wlj anilinium
+CC-CT-CT    63.0       113.1      HIS(OL)
+CW-CT-CT    63.0       114.0     jtr: HID CA-CB-CG
+CV-CT-CT    63.0       114.0     jtr: HIE CA-CB-CG
+CX-CT-CT    63.0       114.0     jtr: HIP CA-CB-CG
+CC-CT-HC     35.       109.5
+CM-CT-HC     35.       109.5
+C=-CT-HC     35.       109.5      wlj
+CT-CT-CT     58.35     112.7      CHARMM 22 parameter file
+CF-CF-CF     58.35     112.7      wlj
+C3-CT-C3     40.       109.5
+C2-CT-C2     40.       109.5
+C2-CT-C3     40.       109.5
+C3-CT-C     63.        109.5    from CA-CT-CT 
+CT-CT-HC     37.5      110.7      CHARMM 22 
+CT-HC-DM     37.5      109.47     wlj
+CT-HC-HC      0.        37.0      wlj
+DM-HC-HC      0.       109.47     wlj
+CT-OS-DM    10.0       109.47     wlj
+CA-OS-DM    10.0       109.47     wlj
+CT-OH-DM    10.0       109.47     wlj
+CA-OH-DM    10.0       109.47     wlj
+OH-HO-DM    10.0       109.47     wlj
+HO-OH-DM    10.0       109.47     wlj
+CT-S -DM    10.0       109.47     wlj
+CT-SH-DM    10.0       109.47     wlj
+SH-HS-DM    10.0       109.47     wlj
+NZ-CZ-DM    10.0       90.0       wlj
+CA-NT-DM    10.0       109.5      wlj
+NO-ON-DM    10.0       109.5      wlj
+C -N -DM    10.0       109.5      wlj
+DM-ON-DM    10.0       109.5      wlj
+DM-NT-H     10.0       100.       wlj
+DM-N -H     10.0       100.       wlj
+DM-N3-CT    10.0       100.       wlj
+DM-N3-CA    10.0       100.       wlj
+DM-N3-CR    10.0       100.       wlj
+CR-OS-DM    10.0       125.       wlj
+CW-OS-DM    10.0       125.       wlj
+CB-OS-DM    10.0       125.       wlj
+NB-OS-DM    10.0       125.       wlj
+NB-NB-DM    10.0       125.       wlj
+CR-NB-DM    10.0       125.       wlj
+NA-NB-DM    10.0       125.       wlj
+CW-S -DM    10.0       130.       wlj
+NB-S -DM    10.0       130.       wlj
+CR-S -DM    10.0       130.       wlj
+CT-CT-N     80.0       109.7      ALA    JACS 94, 2657
+CT-CT-NM    80.0       109.7      ALA    JACS 94, 2657
+CT-CT-N*     50.       109.5
+CT-CO-N*     50.       109.5      jtr (12/7/01)
+CT-CT-N2    80.0       111.2      ARG   JCP 76, 1439
+C -CT-N3    80.0       111.2      Amino terminal residues
+C -CT-NT    80.0       111.2      wlj
+CA-CT-NT    80.0       111.2      wlj
+CA-CT-NA    80.0       111.2      wlj
+CT-CT-N3    80.0       111.2      LYS(OL)   JCP 76, 1439
+CT-CT-OH     50.       109.5
+CA-CT-OH     50.       109.5      wlj
+CT-CT-OS     50.       109.5
+CA-CT-OS     50.       109.5
+CT-CT-S     50.        114.7      CYX            SCHERAGA  JPC 79,1428
+CT-CT-SH    50.0       108.6      CYS
+CA-CT-S     50.        114.7      wlj
+CW-CT-S     50.        114.7      wlj
+NT-NT-H     35.0       106.0      wlj 1/14
+CT-NT-H     35.0       109.5
+CA-NT-H     35.0       116.0     wlj    anilines 9/06
+CA-NT-CA    50.0       116.0     wlj    anilines 9/06
+CA-NT-CT    50.0       116.0     wlj    anilines 9/06
+CP-NT-H     35.0       116.0     JT-R 2014/04 aminothiophenes, from wlj    anilines 9/06
+CP-NT-CT    50.0       116.0     JT-R 2014/04 aminothiophenes, from wlj    anilines 9/06
+CT-NT-CT    51.8       107.2     wlj - MM3 based JACS 112, 8314 (90)
+CT-NT-CH    51.8       107.2             "
+CT-NT-C2    51.8       107.2             "
+CT-NT-C3    51.8       107.2             "
+CH-NT-CH    51.8       107.2             "
+CH-NT-C2    51.8       107.2             "
+CH-NT-C3    51.8       107.2             "
+C2-NT-C2    51.8       107.2             "
+C2-NT-C3    51.8       107.2             "
+C3-NT-C3    51.8       107.2             "
+HC-CT-HC     33.       107.8      CHARMM 22 
+DM-CM-HC     10.        90.0      wlj
+DM-C=-HC     10.        90.0      wlj
+DM-CM-CM      2.        90.0      wlj
+DM-CZ-CZ      5.        90.0      wlj
+DM-CZ-CA      5.        90.0      wlj
+DM-CZ-HC      5.        90.0      wlj
+DM-CM-C=      2.        90.0      wlj
+DM-C=-C=      2.        90.0      wlj
+DM-C=-CM      2.        90.0      wlj
+DM-DM-DM     33.       109.47     wlj
+DM-HC-DM     33.       109.47     wlj
+DM-HA-DM     33.       109.47     wlj
+DM-HO-DM     33.       109.47     wlj
+DM-HS-DM     33.       109.47     wlj
+DM-H -DM     33.       109.47     wlj
+DM-OS-DM      5.       109.47     wlj
+DM-OH-DM      5.       109.47     wlj
+DM-S -DM      5.       109.47     wlj
+DM-SH-DM      5.       109.47     wlj
+DM-F -DM     33.       109.47     wlj
+DM-Cl-DM     33.       109.47     wlj
+DM-Br-DM     33.       109.47     wlj
+DM-I -DM     33.       109.47     wlj
+CY-CY-HC    37.5       117.2      cyclopropanes - wlj  10/97
+YC-CY-CY    30.0        79.2            "
+CY-CY-CY    30.0        83.0            "
+CY-CY-CT    37.5       117.2            "
+CY-CY-CA    37.5       121.3            "
+CY-CY-CP    37.5       121.3            "
+CY-CT-HC    37.5       110.7            "
+HC-CY-HC     35.       114.3            "
+HC-CY-CT     35.       114.3            "
+CT-CY-CT     35.       114.3            "
+HC-CY-CA     35.       114.0            "
+HC-CY-CP     35.       114.0            "
+CA-CA-CY     70.       120.7            "
+CY-CM-HC     35.       135.0      wlj
+CY-CY-N$     80.        89.0      small rings - wlj
+CY-N$-C$     50.        94.0            "
+N$-C$-CY     70.        91.0            "
+CY-CY-C$     63.        85.0            "
+N$-C$-O      80.       134.0            "
+CY-C$-O      80.       134.0            "
+HC-CY-N$     35.       111.0            "
+HC-CY-N      35.       108.0            "
+HC-CY-C$    37.5       110.0            "
+CY-CY-N     37.5       126.0            "
+HC-CY-S     37.5       108.0            "
+CY-CY-S      55.       128.0            "
+CY-N -C      55.       128.0            "
+CY-N -H      40.       113.0            "
+N -CY-C$     70.       117.0            "
+N$-CY-S      55.       109.0            "
+C$-N$-CT     55.       127.0            "
+CY-S -CT     62.        94.0            "
+CY-N$-CT     50.       126.0            "
+N$-CT-CT     80.       110.0            "
+N$-CT-HC     35.       109.5            "
+N$-CT-C      80.       113.0            "
+CY-O$-CY     60.        90.0            "
+CY-CY-O$     50.        90.0            "
+CT-CY-O$    37.5       117.2            "
+HC-CY-O$    37.5       117.2            "
+HC-CT-N      35.       109.5
+HC-CT-NM     35.       109.5
+HC-CT-N*     35.       109.5      jtr (12/7/01)
+HC-CO-N*     35.       109.5
+HC-CT-NA     35.       109.5      copy from above for CytH+ (jtr 5-14-91)
+HC-CT-N2     35.       109.5
+HC-CT-N3     35.       109.5
+HC-CT-NT     35.       109.5      JACS 115, 9620 (93)
+DM-H -NT     10.       109.5      wlj
+HC-CT-NC     35.       109.5
+HC-CT-OH     35.       109.5
+HC-CT-OS    35.0       109.5      SUG
+HC-CT-S      35.       109.5
+HC-CT-P      41.       109.5      wlj 11/95 MM3 based JACS 114, 8536 (92)
+CT-CT-P      43.       109.5             "
+CA-CT-P      43.       109.5             "
+CT-CT-P+     43.       109.5      wlj 9/97
+CT-P+-CT     45.       109.5      " AMBER OS-P-OS
+HC-CT-P+     41.       109.5      "
+HC-CT-SH     35.       109.5
+N*-CT-OS     50.       109.5
+N*-CO-OS     50.       109.5     jtr (12/7/01)
+CW-CW-NB    70.        120.0 
+HA-CV-NB     35.       121.7     wlj 6/13
+C!-CV-NB     35.       121.7     wlj 6/13
+H4-CW-NA     35.       120.0
+HA-CA-NA     35.       120.0
+C -N -C2    50.        121.9      PRO(OL)
+C -N -C3    50.        121.9      
+C -N -CH    50.        121.9      AA(OL)
+C -N -CT    50.        121.9
+C -NM-CT    50.        121.9
+C -N -CA    50.        121.9      wlj
+CA-N2-CA    50.        121.9      wlj
+C -N -H     35.        119.8      AA(OL)
+CQ-NC-DM     5.        119.8      wlj    
+C2-N -C3    50.        121.9
+C -N -H2    35.        120.       GLN,ASN                 **
+C2-N -CH    50.        118.       PRO(OL)         DETAR JACS 99,1232
+C2-N -H     38.        118.4      AA(OL)
+C3-N -H     38.        118.4      
+CH-N -H     38.        118.4      AA(OL)
+CT-N -CT    50.        118.       PRO(OL)         DETAR JACS 99,1232
+CT-N2-CT    50.        118.       
+CT-NM-CT    50.        118.       PRO(OL)
+CA-N -CT    50.        118.       wlj
+CA-NC-CT    50.        118.       wlj
+CT-N -H     38.        118.4
+H -N -H     35.        120.       ADE,CYT,GUA,GLN,ASN     **
+H -N2-H     35.        120.      MKD MP2(full)/aug-ccpVTZ  - aminoimidazol, changed from 113.0
+H3-N -H3    35.        120.       ADE,CYT,GUA,GLN,ASN     **
+C -N*-CH    70.        117.6      URA,CYT
+C -N*-CJ    70.        121.6      URA,CYT
+C -N*-CM    70.        121.6      
+C -NA-CM    70.        121.6      copy from above for CytH+ (jtr 5-14-91)
+C -N*-CT     70.       117.6
+C -N*-CO     70.       117.6      jtr 12/11/01
+C -N*-H     35.        119.2
+C3-N*-CB    70.        125.8      9 methylated guan,aden
+C3-N*-CE    70.        128.8      Methylated purines
+C3-N*-CK    70.        128.8
+CB-N*-CE    70.        105.4      GUA,ADE
+CB-N*-CH    70.        125.8      GUA,ADE
+CE-N*-CH    70.        128.8      GUA,ADE
+CE-N*-CT     70.       128.8
+CE-N*-H     35.        127.3
+CH-N*-CJ    70.        121.2      URA,CYT
+CH-N*-CK    70.        128.8
+CJ-N*-CT     70.       121.2
+CJ-N*-H     35.        119.2
+CM-N*-CT     70.       121.2
+CM-N*-CO     70.       121.2       jtr 12/11/01
+CM-N*-H     35.        119.2
+CM-NA-H     35.        119.2       copy from above for CytH+ (jtr 5-14-91)
+C2-N2-CA    50.        123.2       ARG(OL)
+C2-N2-H2    35.        118.4      ARG(OL)
+C2-N2-H3    35.        118.4      ARG(OL)
+C3-N2-CA    50.        123.2       ARG(OL)
+C3-N2-H2    35.        118.4      ARG(OL)
+CA-N2-CT    50.        123.2       ARG(OL)
+CA-N2-H     35.        120.       ARG(OL)
+CQ-N2-H     35.        120.       wlj
+CA-N2-H2    35.        120.       ADE,CYT,GUA,ARG
+CA-N2-H3    35.        120.       ADE,CYT,GUA,ARG
+CT-N2-H3    35.        118.4      ARG(OL)
+CT-N2-H     35.        118.4
+H2-N2-H2    35.        120.       ADE,CYT,GUA,GLN,ASN,ARG
+H3-N2-H3    35.        120.       ADE,CYT,GUA,GLN,ASN,ARG
+C2-N3-H3    35.        109.5      LYS
+C3-N3-H3    35.        109.5
+CT-N3-H3    35.        109.5      LYS
+H3-N3-H3    35.        109.5      LYS
+CT-N3-CT    50.        113.0      proline j.phys chem 1979 p 2361
+CA-N3-CT    55.        114.0      wlj                              
+C -NA-C     70.        126.4      URA
+C -N -C     70.        126.4      wlj
+C -NA-CA    70.        125.2      GUA
+C -N -CQ    70.        125.2      wlj
+C -NA-H     35.        116.8      GUA,URA(2)
+CA-NA-H     35.        118.0      GUA
+CQ-N -H     35.        118.0      wlj
+CC-NA-CP    70.        107.30      HIS(OL)
+CC-NA-CR    70.        120.00      HIS(OL)
+CC-NA-H     35.        120.00      HIS(OL)
+CG-NA-CN    70.        111.6      TRP(OL)
+CA-NA-CC    70.        111.6      TRP(OL)
+CC-NA-CC    70.        111.6      TRP(OL)
+CG-NA-CP    70.        107.3      HIS(OL)
+CG-NA-CR    70.        107.3      HIS(OL)
+CG-NA-H     35.        126.35      HIS(OL)
+CN-NA-CW    70.        111.6      TRP(OL)
+CN-NA-H     35.        123.1       TRP
+CP-NA-H     35.        126.35      HIS(OL)
+CR-NA-H     35.        124.00      HIS(OL)
+CW-NA-H     35.        124.00      JT-R 2014/04  changed back from 129.2       wlj 6/13
+CX-NA-H     35.        124.00      jtr HIP
+CW-NA-CT    70.        124.00      wlj    
+CB-N*-CK    70.        105.4
+CB-N*-CT    70.        125.8
+CB-N*-CO    70.        125.8       jtr (12/7/01)
+CB-N*-H     30.        125.8
+CK-N*-CT    70.        128.8
+CK-N*-CO    70.        128.8       jtr (12/7/01)
+CK-N*-H     30.        128.8
+CB-NA-CK    70.        105.4       wlj
+CB-NA-CT    70.        125.8       wlj
+CB-NA-H     30.        125.8       wlj
+CK-NA-CT    70.        128.8       wlj
+CK-NA-H     30.        128.8       wlj
+CB-NB-CE    70.        103.8      GUA,ADE
+CB-NB-CK    70.        103.8
+CC-NB-CP    70.        105.3       HIS(OL)
+CC-NB-CR    70.        117.0       HIS(OL)
+CF-NB-CP    70.        105.3      HIS(OL)
+CF-NB-CR    70.        105.3      HIS(OL)
+CR-NB-CV    70.        110.0      HIS(OL) wlj 1/97
+CR-NB-CB    70.        110.0      wlj
+CR-NB-CW    70.        110.0
+C -NC-CA    70.        120.5      CYT
+C -NC-CT    70.        120.5      imine - check
+C -N=-C=    70.        120.5      imine - check
+CA-NC-CB    70.        112.2      GUA
+CA-NC-CI    70.        118.6      ADE
+CA-NC-CQ    70.        118.6
+CQ-NC-CQ    70.        118.6      wlj 1,3,5-triazine
+CB-NC-CI    70.        111.0      ADE
+CB-NC-CQ    70.        111.0
+CR-NC-CQ    70.        111.0      wlj
+C2-NT-H     43.2       108.1      wlj MM3 based
+C3-NT-H     43.2       108.1      wlj MM3 based
+CH-NT-H     43.2       108.1      wlj MM3 based
+H -NT-H     43.6       106.4      wlj MM3 based
+H -N3-H     43.6       109.5      wlj            
+H -N -OH    35.        110.2      wlj
+C -N -OH    46.        115.7      wlj
+N -OH-HO    49.        105.4      wlj
+C -OH-HO    35.        113.0      TYR(PHENOL)     HARMONY MEOH
+CA-OH-HO    35.        113.0
+CP-OH-HO    35.        109.0     JT-R 2014/04 hydroxy thiophene
+C -O -DM    35.        113.0
+DM-O -DM    10.        117.0
+CM-OH-HO    35.        109.0      wlj
+C2-OH-HO    55.0       108.5      SUG,SER(OL,mod)
+C3-OH-HO    55.0       108.5      SUG,SER(OL,mod)
+CH-OH-HO    55.0       108.5      THR(OL),SUG
+CT-OH-HO     55.       108.5      
+HO-OH-P     55.0       108.5      SUG(OL)
+C2-OS-C2    100.0      111.8       DME based
+C2-OS-C3    100.0      111.8       DME based
+CH-C -OS    81.        111.4    from FK506, SKF8
+C -OS-CH    83.        116.9    from FK506 C -OS-CZ for SKF8
+C -OS-C2    83.        116.9
+C -OS-C3    83.        116.9
+O -C -OS    83.        123.4    J.Comp.Chem.1990,11,1181 for SKF8
+C -OS-CT    83.        116.9       "
+OS-C -CT    81.        111.4       "
+OS-C -CA    81.        111.4      wlj
+C -OS-CA    83.        116.9      wlj
+CA-CH-OS    80.0       109.5    SUG from AMBER/BOSS for SKF8
+OS-CO-OH     92.6      111.55   Ha,CarbRes 180,207(88)Merz,JCC 15,1019 (94)
+OS-B -OS     92.6      104.5      wlj - temp borate B3LYP
+B -OS-CT     92.6      108.6      wlj - temp borate B3LYP
+OS-CO-OS     92.6      111.55     ACETAL - wlj 2/93
+C3-OS-CO    100.0      113.0        "
+C2-OS-CO    100.0      113.0        "
+CH-OS-CO    100.0      113.0        "
+C2-CO-OS    80.0       109.5        "
+C3-CO-OS    80.0       109.5        "
+C3-CO-C3    40.0       109.5        "
+C2-C2-CO    63.0       112.4        "
+C3-C2-CO    63.0       112.4        "
+OS-CO-CT    50.        109.5       hexopyranoses :  CT-CT-OS - wd 3/95 Glucose
+CO-CT-CT    58.35      112.7        "            :  CT-CT-CT - wd 6/95 Glucose
+CT-CO-OH    50.        109.5        "            :  CT-CT-OH - wd 6/95 Glucose
+CT-CO-HC    37.5       110.7        "            :  CT-CT-HC - wd 6/95 Glucose
+CO-OH-HO    55.        108.5        "            :  CT-OH-HO - wd 6/95 Glucose
+OS-CO-HC    35.0       109.5        "            :  HC-CT-OS - wd 6/95 Glucose
+CO-OS-CT    60.        109.5        "            :  CT-OS-CT - wd 6/95 Glucose
+CO-CT-HC    37.5       110.7        "            :  CT-CT-HC - wd 6/95 Glucose
+CO-CT-OH    50.        109.5        "            :  CT-CT-OH - wd 6/95 Glucose
+OH-CO-HC    35.0       109.5        "            :  HC-CT-OS - wd 6/95 Glucose
+HC-CO-HC    33.        109.5        "            :  HC-CT-HC - wd 6/95
+C2-OS-HO    55.0       108.5      SUG
+CA-OS-P     100.0      120.5      mll
+C2-OS-P     100.0      120.5      SUG(OL)
+C3-OS-P     100.0      120.5     DMPhos based
+CH-OS-CH    100.0      111.8      SUG(dme based)
+CH-OS-HO    55.0       108.5      SUG
+CH-OS-P     100.0      120.5      SUG
+CT-OS-CT     60.       109.5
+Si-OS-Si     20.       145.0      wlj
+CT-OS-Si     40.       121.0      wlj
+Si-OH-HO     40.       117.0      wlj
+CT-Si-OS     60.       105.0      wlj
+CT-Si-OH     60.       107.0      wlj
+CT-Si-CT     37.       112.5      wlj fit to expt
+CT-CT-Si     40.       114.0      wlj fit to expt
+CA-Si-CT     40.       112.5      wlj
+CA-CA-Si     45.       121.0      wlj
+CT-Si-Si     40.       112.0      wlj
+H -Si-Si     25.       110.5      wlj
+OS-Si-OS     60.       110.0      wlj
+Si-CT-HC     35.       110.9      wlj fit to expt
+H -Si-H      33.       109.0      wlj fit to expt
+H -Si-CT     28.       110.5      wlj fit to expt
+H -Si-OH     35.       111.0      wlj
+H -Si-OS     35.       111.0      wlj
+H -Si-CA     30.       110.0      wlj
+F -Si-CT     35.       110.5      wlj
+Cl-Si-CT     35.       110.5      wlj
+Br-Si-CT     35.       110.5      wlj
+I -Si-CT     35.       110.5      wlj
+CT-OS-CA     75.       111.0      wlj 9/97
+CA-OS-CA     75.       116.3    MKD MP2(full)/6-311G(d,p) - biaryl ethers, changed from 111.0
+CT-OS-CM     75.       111.0      wlj
+CT-OS-P     100.       120.5
+CT-OH-P     100.       120.5      jtr 12/10/01
+O -C -O2     80.       126.0      adk
+O2-P -O2    140.0      119.9      SUG(OL)
+O2-P -OH    45.0       108.23     SUG(OL)
+O2-P -OS    100.0      108.23     SUG(OL)
+OH-P -OS    45.0       102.6      SUG(OL)
+OS-P -OS    45.0       102.6      SUG(OL)
+O -P -OH    100.0      108.23     SUG(OL)
+O -P -OS    100.0      108.23     SUG(OL)
+OH-P -OH    45.0       102.6      SUG(OL)
+CT-P -OS    45.0       109.5      wlj 11/95
+CT-P -O2    45.0       109.5      wlj 11/95
+CT-P -O     45.0       109.5      wlj 11/95
+CA-P -OS    45.0       109.5      wlj 11/95
+CA-P -OH    45.0       109.5      wlj 11/95
+CA-P -O     45.0       109.5      wlj 11/95
+C2-S -C3    62.         98.9       MET(OL)
+C2-S -LP    150.        96.7
+C2-S -S     68.        103.7       CYX(OL)        SCHERAGA  JPC 79,1428
+C3-S -LP    150.        96.7
+C3-S -S     68.        103.7       CYX(OL)        SCHERAGA  JPC 79,1428
+CT-S -CT    62.         98.9       MET(OL)
+CR-S -CW    74.         90.0       wlj
+CW-S -CW    74.         97.0       wlj
+CB-S -CB    74.         97.0       wlj
+CB-S -N     74.         92.4       wlj
+CR-S -CB    74.         97.0       wlj
+CW-S -CB    74.         97.0       wlj
+CT-S -LP    150.        96.7
+CT-S -S     68.        103.7       CYX(OL)        SCHERAGA  JPC 79,1428
+LP-S -LP     10.       160.0
+LP-S -S     150.        96.7
+C2-SH-HS    44.         96.0        CYS(OL)
+C2-SH-LP    150.        96.7
+C3-SH-HS    44.         96.0        CYS(OL)
+C3-SH-LP    150.        96.7
+CT-SH-HS    44.         96.0        CYS(OL)
+CA-SH-HS    50.         96.0        wlj
+CT-SH-LP    150.        96.7
+HS-SH-HS     35.        92.07
+HS-SH-LP    150.        96.7
+LP-SH-LP     10.       160.0
+P -OS-P     100.       120.5
+C9-C8-C8    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C8-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-C8    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C9-C7-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-C8    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C8-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-C8    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C8-C7-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-C7    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-CT    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-CH    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-C2    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+C7-C7-C3    70.        118.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C8-CT    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C8-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C8-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C8-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C8-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C8-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C8-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C8-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C8-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C3-C8-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C7-CT    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C7-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C7-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CT-C7-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C7-CH    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C7-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CH-C7-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C7-C2    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C2-C7-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+C3-C7-C3    70.        124.     OPLS hydrocarbons ff (jtr 5-14-91)
+CA-OS-C2   100.0       111.8    AMBER(MMOD) 9/9/91
+CA-CT-CA    40.0       109.5      "
+CA-CT-C2    63.0       114.0      "           
+CA-CT-C     63.0       112.0    wlj
+N -CT-C2    80.        109.7    Added DSM (from N -CT-C3)
+HC-CT-C2    35.        109.5    Added DSM (from C -CT-HC)
+C -CT-C2    63.        111.1    Added DSM (from C3-CT-C )
+CT-CA-NA    70.        120.00   Added DSM (from CT-CC-NA)
+CA-NA-CA    70.        125.2    Added DSM (from C -NA-CA)
+CA-CA-NB    70.        108.7    Added DSM (from CA-CA-NA)
+NA-CA-NB    70.        123.3    Added DSM (from NA-CA-NC)
+CA-NB-CA    70.        125.2    Added DSM (from C -NA-CA)
+HA-CA-NB     35.       119.1    Added DSM (from HC-CM-NA)
+CA-CA-N     70.        120.0    Added DSM (from CA-CA-NA)
+CA-N -H     35.        119.8    Added DSM (from C -N -H)
+CU-N -H     35.        119.8    wlj                         
+CW-N -H     35.        119.8    wlj                         
+CS-N -H     35.        119.8    wlj                         
+CB-CT-HC     35.       109.5    Added DSM (from CA-CT-HC)
+CA-CB-CT    70.        120.     Added DSM (from CA-CA-CT)
+CB-CA-NA    70.        108.7    Added DSM (from CA-CA-NA)
+CA-CA-CC    85.        120.     Added DSM (from CA-CA-CA)
+CB-CB-CT    70.        120.     Added DSM (from CA-CA-CT)
+CB-CB-CC    85.        120.     Added DSM (from CA-CA-CA)
+CB-CT-CT    63.        114.     Added DSM (from CA-CT-CT)
+CT-CT-F     50.        109.5    PAK F-CT-HC (emd 5-09-94)
+CF-CF-F     50.        109.5    wlj
+C2-C2-F     50.        109.5
+CA-CT-F     50.        109.5    wlj 
+CA-CF-F     50.        109.5    wlj 
+CM-CT-F     50.        109.5    wlj 
+F -CT-F     77.        109.1    PAK F-CT-F  (emd 5-09-94)
+F -CF-F     77.        109.1    wlj                        
+HC-CT-F     40.        107.0    wlj
+CT-C -C     80.        117.2    (JP 1-6-91)  SKF8
+C -C -O     80.        121.4    ketone (JP 1-5-91) SKF8
+C -C -N     70.        116.6    (JP 1-5-91) SKF8
+C9-C8-SY    70.        118.
+C8-SY-C3    62.        98.9
+OY-SY-N    120.0      107.0
+OY-SY-OY   104.0      119.0
+OY-SY-OH    74.0      108.7
+SY-OH-HO    74.0      110.0 
+OY-SZ-CT    74.0      107.0
+OY-SY-CT    74.0      108.9
+OY-SY-CA    74.       107.2
+N -SY-CA   100.       103.0
+SY-CA-CA    85.       119.4
+SY-CT-HC    35.0      109.5
+SZ-CT-HC    35.0      109.5
+CT-SY-CT    62.0      102.0       
+CA-SY-CT    62.0      102.0
+CR-SY-CT    62.0      102.0
+CT-SZ-CT    62.0       96.0
+CT-CT-SY    50.0      108.6
+CT-CT-SZ    50.0      108.6
+OH-SY-CT    75.0       96.4
+OH-SY-CA    75.0       96.4
+N -SY-CT   100.0      103.0
+SY-N -CT    50.       120.0
+H -N -SY   100.0      111.0
+OS-C -N     81.        111.4    bhap,                   copy from OS-C -CT      rcr HIVRT
+CT-NT-SY    50.0      108.6     bhap,                   copy from CT-CT-SY      rcr HIVRT
+C -CT-F     50.        109.5    bhap,                   copy from CT-CT-F       rcr HIVRT
+SY-CT-F     50.        109.5    bhap,                   copy from CT-CT-F       rcr HIVRT
+SY-NT-H     35.0       115.0    bhap,                   adjusted from CT-NT-H   rcr HIVRT
+C -CW-NA    85.        120.     bhap,                   copy from C -CA-CA      rcr HIVRT
+NT-C -CW    70.        116.0    bhap,                   copy from CT-C -CT      rcr HIVRT
+C -CW-CS    85.        120.     bhap,                   copy from C -CA-CA      rcr HIVRT
+CB-CS-HA     35.       120.0    bhap,                   copy from CB-CA-HA      rcr HIVRT
+CW-C -O     80.        120.4    bhap,                   copy from CA-C -O       rcr HIVRT
+C -NT-CT    63.0       111.1    bhap,                   copy from C -CT-CT      rcr HIVRT
+C -CT-C     63.0       111.1    lac,                    copy from C -CT-CT      rcr HIVRT
+C -CT-OS     50.       109.5    lac,                    copy from CT-CT-OS      rcr HIVRT
+N -CT-OS     50.       109.5    lac,                    copy from CT-CT-OS      rcr HIVRT
+NT-C -O     80.        120.4    nev,                    copy from CT-C -O       rcr HIVRT
+NT-C -CT    70.        116.0    nev,                    copy from CT-C -CT      rcr HIVRT
+CA-NT-C     63.0       112.0    nev,                    copy from CA-CT-C       rcr HIVRT
+CA-NT-SY    50.0      108.6     nev,                    copy from CT-CT-SY      rcr HIVRT
+OY-SY-NT    74.0      108.9     nev,                    copy from OY-SY-CT      rcr HIVRT
+NT-SY-CT    62.0      102.0     nev,                    copy from CT-SY-CT      rcr HIVRT
+NT-CT-S     50.        114.7    nev,                    copy from CT-CT-S       rcr HIVRT
+HC-CY-NT     35.       114.3    nev,                    copy from HC-CY-CT      rcr HIVRT
+CY-CY-NT    37.5       117.2    nev,                    copy from CY-CY-CT      rcr HIVRT
+CA-NT-CY    50.        109.5    nev,                    copy from CA-NT-CT      rcr HIVRT
+NC-CA-Cl    75.        120.0    nev,                    copy from CA-CA-Cl      rcr HIVRT
+NC-CA-NT     70.       116.0    nev,                    copy from NC-CA-CT      rcr HIVRT
+CM-CM-CY     70.       124.0    hept,                   copy from CM-CM-CT      rcr HIVRT
+CM-CY-HC     35.       109.5    hept,                   copy from CM-CT-HC      rcr HIVRT
+CM-CY-CY    63.        114.     hept,                   copy from CA-CT-CT      rcr HIVRT
+C -CM-CY     70.       119.7    hept,                   copy from C -CM-CT      rcr HIVRT
+N*-CM-CT    70.        120.     hept,                   copy from PHE(OL)       rcr HIVRT
+NA-CM-CT    70.        120.     hept,                   copy from PHE(OL)       rcr HIVRT
+S -CM-CM    85.        119.4    hept,                   copy from SY-CA-CA      rcr HIVRT
+S -CM-N*    85.        119.4    hept,                   copy from SY-CA-CA      rcr HIVRT
+S -CM-NA    85.        119.4    hept,                   copy from SY-CA-CA      rcr HIVRT
+N*-CM-OS    70.        120.     hept,                   copy from CA-CA-OS      rcr HIVRT
+NA-CM-OS    70.        120.     hept,                   copy from CA-CA-OS      rcr HIVRT
+CA-S -CM    62.        104.2    hept,                   adjusted from CT-S -CT  rcr HIVRT
+CM-OS-CA    75.        111.0    hept,                   copy from CT-S -CT      rcr HIVRT
+CM-CT-CA    40.0       109.5    hept,                   copy from CA-CT-CA      rcr HIVRT
+S -CA-CA    85.        119.4    thioanisole             copy from SY-CA-CA      rcr HIVRT
+P -CA-CA    85.        119.4    
+CA-S -CT    65.         97.0    thioanisole JT-R 2014/04 MP2/cc-pVTZ (was 62,104.2 adj. rcr HIVRT)
+CZ-S -CT    65.        100.0    wlj 9/06 
+C -N -Zn    20.        126.                             Merz, JACS 113, 8262 (1991)
+HO-OH-Zn   100.        126.
+N -Zn-N     20.        109.5
+N -Zn-O     20.        109.5
+SA-CP-CY    70.        121.1    JT-R 2014/04 cyclopropyl thiophene MP2/aug-cc-pVTZ
+CS-CP-CY    70.        128.4    JT-R 2014/04 cyclopropyl thiophene MP2/aug-cc-pVTZ
+SA-CP-NT    70.        120.8    JT-R 2014/04 amino thiophene MP2/aug-cc-pVTZ
+CS-CP-NT    70.        128.6    JT-R 2014/04 amino thiophene MP2/aug-cc-pVTZ
+SA-CP-CS    70.        111.0    MKD New Thiophene MP2(full)/6-311G(d,p)
+SA-CP-HA    35.        120.0    MKD New Thiophene MP2(full)/6-311G(d,p)
+CS-CP-HA    35.        128.2    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-CS-HA    35.        123.1    MKD New Thiophene MP2(full)/6-311G(d,p)
+CS-CS-CP    70.        112.3    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-C!-CA    63.        120.5    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-C!-NC    63.        116.8    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-C!-NA    63.        117.2    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-C!-C=    63.        123.8    MKD New Thiophene MP2(full)/6-311G(d,p)   
+SA-CP-C!    63.        121.7    MKD New Thiophene MP2(full)/6-311G(d,p)
+CS-CP-C!    63.        127.7    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-CS-C!    63.        123.6    MKD New Thiophene MP2(full)/6-311G(d,p)
+CP-SA-CP    70.         92.2    MKD New Thiophene MP2(full)/6-311G(d,p)
+CR-SA-NB    70.         85.7    JT-R thiatriazoles
+NC-C!-NC    70.        126.3    MKD MP2(full)/6-311G(d,p) new
+C!-CR-NA    70.        123.1    MKD MP2(full)/6-311G(d,p) new
+CR-C!-NC    70.        116.6    MKD MP2(full)/6-311G(d,p) new
+CV-C!-NC    70.        116.6    wlj 6/13                       
+CW-C!-NC    70.        117.1    MKD MP2(full)/6-311G(d,p) new
+C=-C!-NA    70.        119.6    MKD MP2(full)/6-311G(d,p) new
+C -NA-C!    70.        126.6    MKD MP2(full)/6-311G(d,p) new
+C!-NA-H     35.        118.0    MKD MP2(full)/6-311G(d,p) new
+C=-CM-C     85.        121.7    MKD MP2(full)/6-311G(d,p) new
+HC-C=-C!    35.        119.9    MKD MP2(full)/6-311G(d,p) new
+CW-C!-NA    70.        116.4    MKD MP2(full)/6-311G(d,p) new
+C=-C!-CW    63.        124.7    MKD MP2(full)/6-311G(d,p) new
+C!-C=-C=    70.        118.1    MKD MP2(full)/6-311G(d,p) new
+CS-C!-NC    63.        117.0    MKD MP2(full)/6-311G(d,p) new
+C!-NA-CW    63.        125.2    MKD MP2(full)/6-311G(d,p) new
+NA-C!-NC    63.        116.2    MKD MP2(full)/6-311G(d,p) new
+CS-C!-NA    63.        116.8    MKD MP2(full)/6-311G(d,p) new
+C=-C!-CS    63.        124.2    MKD MP2(full)/6-311G(d,p) new
+C!-C!-NA    63.        116.6    MKD MP2(full)/6-311G(d,p) new
+C=-C!-C!    63.        123.9    MKD MP2(full)/6-311G(d,p) new
+CR-C!-NA    63.        114.3    MKD MP2(full)/6-311G(d,p) new
+C=-C!-CR    63.        126.0    MKD MP2(full)/6-311G(d,p) new
+NA-C!-CA    63.        119.8    MKD MP2(full)/6-311G(d,p) new
+C!-NA-NB    63.        119.9    MKD MP2(full)/6-311G(d,p) new
+NA-C!-NA    63.        115.7    MKD MP2(full)/6-311G(d,p) new only give NA-C!-NX in paper?
+NX-C!-NC    63.        116.2    MKD synonym for NA-C!-NC  
+NX-CW-HA    35.        121.6    MKD synonym for HA-CW-NA
+NX-CW-CS    70.        107.7    MKD synonym for NA-CW-CS
+CW-NX-C!    63.        125.2    MKD synonym for C!-NA-CW
+CW-NX-CW    70.        109.8    MKD synonym for CW-NA-CW
+NX-C!-CA    63.        119.8    MKD synonym for NA-C!-CA
+C!-NX-NB    63.        119.9    MKD synonym for C!-NA-NB   
+NB-NX-CW    56.        113.1    MKD synonym for NB-NA-CW
+NX-C!-NA    63.        115.7    MKD synonym for NA-C!-NA
+C=-C!-NX    63.        123.8    MKD MP2(full)/6-311G(d,p) - new - external NA connected to pyridone
+HA-CU-CS    35.        129.2    MKD MP2(full)/6-311G(d,p) - new pyrazole
+CU-NB-NX    70.        104.1    MKD synonym for CU-NB-NA
+HA-CS-CU    35.        128.5    MKD MP2(full)/6-311G(d,p) - new pyrazole
+N2-CR-NA    70.        126.65   MKD MP2(full)/aug-ccpVTZ  - aminoimidazol
+H -N2-CR    35.        120.     MKD MP2(full)/aug-ccpVTZ  - aminoimidazol
+NE-C -NE    70.        105.8    MKD MP2(full)/6-311G(d,p) - hydantoin
+O -C -NE    70.        127.5    MKD MP2(full)/6-311G(d,p) - hydantoin
+CT-NE-C     70.        112.5    MKD MP2(full)/6-311G(d,p) - hydantoin
+C -CT-NE    70.        102.8    MKD MP2(full)/6-311G(d,p) - hydantoin
+HC-CT-NE    35.        109.5    MKD MP2(full)/6-311G(d,p) - hydantoin
+C!-NE-C     63.        124.0    MKD MP2(full)/6-311G(d,p) - hydantoin
+CA-C!-NE    63.        120.0    MKD 
+CT-NE-CT    70.        123.2    MKD MP2(full)/6-311G(d,p) - hydantoin
+C -NE-C     70.        112.1    MKD MP2(full)/6-311G(d,p) - hydantoin
+CT-C -NE    70.        105.8    MKD MP2(full)/6-311G(d,p) - hydantoin
+H -NE-C     35.        112.5    MKD MP2(full)/6-311G(d,p) - hydantoin
+H -NE-CT    35.        123.2    MKD MP2(full)/6-311G(d,p) - hydantoin
+CT-CT-NE    70.        109.5    MKD 
+C!-NC-NC    70.        117.0    MKD synonym for CA-NC-NC
+CQ-NC-NC    70.        118.2    MKD MP2(full)/6-311G(d,p)
+NB-CR-NB    70.        112.2    MKD MP2(full)/6-311++G(d,p) - negatively charged tetrazole
+NB-NB-NB    70.        109.4    MKD MP2(full)/6-311++G(d,p) - negatively charged tetrazole
+NB-NB-OA    70.        110.0    JT-R oxatriazoles
+NB-NB-NA    70.        107.0    wlj 6/13
+NB-NA-CW    56.        111.4    wlj 6/13
+NC-CA-OS    70.        120.0    MKD MP2(full)/6-311G(d,p)
+CA-CT-N     80.0       111.2    MKD parameter taken from CA-CT-NT
+C!-CA-OH    70.        120.     MKD synonym for CA-CA-OH
+CQ-NC-C!    70.        118.6    MKD synonym for CA-NC-CQ
+HC-CT-CQ    35.        109.5    MKD synonym for HC-CT-CA
+CW-CT-C     63.0       111.0    MKD MP2/6-311G(d,p)
+CR-NA-CT    70.        126.2    MKD MP2/6-311G(d,p)
+NA-CT-C     63.        109.6    MKD MP2/6-311G(d,p)
+C!-CW-NS    70.        121.6    MKD synonym for C!-CW-NA
+CS-CW-NS    70.        107.7    MKD synonym for CS-CW-NA   
+CW-NS-CW    70.        109.8    MKD synonym for CW-NA-CW
+CW-NS-CT    70.        124.00   MKD synonym for CW-NA-CT
+NS-CT-HC    35.        109.5    MKD synonym for HC-CT-NA 
+NS-CW-HA    35.        121.6    MKD synonym for NA-CW-HA    
+HC-CT-CU    35.        110.3    MKD MP2(full)/6-311G(d,p) - 3-methylisoxazole
+CS-CU-CT    70.        129.4    MKD MP2(full)/6-311G(d,p) - 3-methylisoxazole
+
+

--- a/moltemplate/force_fields/convert_OPLSAA_to_LT/oplsaa2lt.py
+++ b/moltemplate/force_fields/convert_OPLSAA_to_LT/oplsaa2lt.py
@@ -1,0 +1,346 @@
+#!/usr/bin/env python3
+
+
+from oplsaa2lt_utils import (bond_header, file_equivalences_header,
+                   file_header, closing_stuff, nb_header,
+                   angle_header, dihedral_header, improper_header)
+
+from oplsaa2lt_classes import Atom, Bond, Angle, Dihedral, Improper
+
+FILE_WITH_TYPES_AND_DIHEDRALS = "./Jorgensen_et_al-2024-The_Journal_of_Physical_Chemistry_B.sup-2.txt"
+FILE_WITH_BOND_AND_ANGLES = "./Jorgensen_et_al-2024-The_Journal_of_Physical_Chemistry_B.sup-3.txt"
+
+NEW_LT_FILENAME = "oplsaa2023.lt"
+
+TYPE_CONVERSION_TUPLES = (
+    ('C:', "C°"), # moltemplate doesn't like :
+    ("C$", "C^"), # $ is used by moltemplate
+    ("N$", "N^"), # $ is used by moltemplate
+    ("O$", "O^"), # $ is used by moltemplate
+    ("C#", "C|"), # moltemplate doesn't like #
+    ("N*", "N§"), # leaving N* would create a mess in bonded interactions
+
+)
+
+
+def rename_type(ty: str) -> str:
+    """
+    A function to "clean" an atom type name, changing problematic characters
+
+    Args:
+        ty (str): the type string that has to be renamed
+
+    Returns:
+        the type name, "cleaned up"
+    """
+    ty = ty.strip()
+    for orig, changed in TYPE_CONVERSION_TUPLES:
+        ty = ty.replace(orig, changed)
+    return ty
+
+
+def parse_atom_line(atom_line) -> Atom|None:
+    if not atom_line[5:7].strip():
+        return None
+    typ, an, at, charge, sigma, epsilon, *comment = atom_line.split()
+    comment = " ".join(comment)
+    if "water" in comment.lower():
+        return None
+    return Atom(type_id=int(typ),
+                atomic_number=int(an),
+                type_str=rename_type(at),
+                charge=charge,
+                sigma=sigma,
+                epsilon=epsilon,
+                comment=comment)
+
+
+def parse_bond_line(bond_line) -> Bond|None:
+    types = list(map(rename_type, bond_line[:5].split('-')))
+    k, eq, *comment = bond_line[5:].split()
+    comment = " ".join(comment)
+    if "water" in comment.lower() or "OW" in types or "HW" in types:
+        return None
+    return Bond(types=types, k=k, eq=eq, comment=comment)
+
+
+def parse_angle_line(angle_line) -> Angle|None:
+    types = list(map(rename_type, angle_line[:8].split('-')))
+    k, eq, *comment = angle_line[8:].split()
+    comment = " ".join(comment)
+    if "water" in comment.lower() or "OW" in types or "HW" in types:
+        return None
+    return Angle(types=types, k=k, eq=eq, comment=comment)
+
+
+def get_bonds_and_angles(input_lines) -> tuple[list[Bond], list[Angle]]:
+    loaded_bonds: list[Bond] = []
+    loaded_angles: list[Angle] = []
+    read_bond = True
+    for l in input_lines:
+        if l.startswith("*") or l.startswith("#") or l.startswith('"""'):
+            continue
+        if l=="\n":
+            read_bond = False
+            continue
+        if read_bond:
+            parsed_bond = parse_bond_line(l)
+            if parsed_bond is not None:
+                loaded_bonds.append(parsed_bond)
+        else:
+            parsed_angle = parse_angle_line(l)
+            if parsed_angle is not None:
+                loaded_angles.append(parsed_angle)
+    return loaded_bonds, loaded_angles
+
+
+def get_dihedrals_and_impropers(input_lines) -> tuple[list[Dihedral], list[Improper]]:
+    read_dihedrals = False
+    loaded_dihedrals: list[Dihedral] = []
+    loaded_impropers: list[Improper] = []
+    DEFINITION_START, DEFINITION_END = 47, 60
+    # NOTE: there is a strange dihedral definition; it has as the last type C(O),
+    # which is not defined anywhere, so it will never be matched...
+    # I kept the range 47:60, so the strange dihedral is still read (and commented), but
+    # doing so creates a problem in a line in which the comments are closer to the
+    # dihedral definition, hence the 'if clause' for the "P in" case.
+    for l in input_lines:
+        if l.startswith("#") or l.startswith("Type"):
+            continue
+        if "The following are the Fourier coefficients" in l:
+            read_dihedrals = True
+            continue
+        if read_dihedrals:
+            items = l[:DEFINITION_START].split()
+            if len(items) <= 1:
+                continue
+            _type_id, v1, v2, v3, v4 = items
+            dihed_definition = l[DEFINITION_START:DEFINITION_END].strip()
+            if dihed_definition in ("Dummy", "", "Harmonic Rest"):
+                continue
+            if dihed_definition.endswith("P in"):
+                dihed_definition = dihed_definition.replace("P in", "P")
+            types = list(map(rename_type, dihed_definition.split('-')))
+            comment = l[DEFINITION_END+1:].strip()
+            #if dihed_definition == "HC-CT-CT-C(O)"
+            if "improper" in comment:
+                loaded_impropers.append(
+                    Improper(types=types, v1=v1, v2=v2, v3=v3, v4=v4, comment=comment))
+            else:
+                loaded_dihedrals.append(
+                    Dihedral(types=types, v1=v1, v2=v2, v3=v3, v4=v4, comment=comment))
+    return loaded_dihedrals, loaded_impropers
+
+
+################################################################################################
+################################################################################################
+# LET'S START PARSING THE FF FILES
+################################################################################################
+################################################################################################
+
+with open(FILE_WITH_BOND_AND_ANGLES) as f:
+    lines = f.readlines()
+bonds, angles = get_bonds_and_angles(lines)
+
+with open(FILE_WITH_TYPES_AND_DIHEDRALS) as f:
+    lines = f.readlines()
+dihedrals, impropers = get_dihedrals_and_impropers(lines)
+
+# NOTE: PROBLEM WITH SAME-TYPES BONDED INTERACTIONS...
+# the same dihedral (from atom types POV) can have != parameters, based on comment...
+#  e.g.:
+#   102   0.000     5.500     0.00      0.0        O -C -OH-HO     carboxylic acid - aliphatic
+#   210   0.000     5.000     0.00      0.0        O -C -OH-HO     benzoic acids
+# the same problem is observed also for bonds and angles...
+def check_uniqueness(
+        of_what: list[Dihedral]|list[Improper]|list[Angle]|list[Bond],
+        skip_equal_parameters: bool = False):
+    for idx, it1 in enumerate(of_what):
+        if it1.to_skip:
+            continue
+        for it2 in of_what[idx+1:]:
+            if it1.types == it2.types:
+                it2.to_comment = True
+                it1_coeff = it1.coeff_line.lstrip("#").split("#")[0]
+                it2_coeff = it2.coeff_line.lstrip("#").split("#")[0]
+                #print(it1_coeff, it2_coeff)
+                if it1_coeff == it2_coeff and skip_equal_parameters:
+                    it2.to_skip = True
+
+for interactions in [bonds, angles, dihedrals, impropers]:
+    interactions.sort(key=lambda k: k.typename)
+    interactions.sort(key=lambda k: k.sort_key)
+    check_uniqueness(interactions, skip_equal_parameters=True)
+
+
+################################################################################################
+# LET'S ADD SOME WATER MODELS 
+################################################################################################
+
+STARTING_WAT_TYPE = 9999
+wat_atoms: list[Atom] = []
+
+# TIP3P water
+# the same bonded interactions are good for TIP4P and TIP5P
+# (LAMMPS proposes these k values if one want to go with a flexible TIP3P model;
+#  note that they are different from the TIP3F, TIP4F and TIP5F parameters in the old oplsaa.lt)
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-0, atomic_number=16, type_str="tipO", charge="-0.830", sigma="3.188", epsilon="0.102", comment="TIP3P/F water O, long-range Coulombic solver"))
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-1, atomic_number=1, type_str="tipH", charge="+0.415", sigma="0.0", epsilon="0.0", comment="TIP3P/F water H, long-range Coulombic solver"))
+bonds.append(Bond(types=["tipO", "tipH"], k="450.00", eq="0.9572", comment="TIP3/4/5P/F O-H"))
+angles.append(Angle(types=["tipH", "tipO", "tipH"], k="55.00", eq="104.52", comment="TIP3/4/5P/F H-O-H"))
+
+# TIP4P water
+# user should change the pair_style to the one that treat internally the O-M interaction,
+#   and so the O-M distance (0.1250) should be added there and not as a bond...
+# also, this should not be used without fix shake, so no flexible variant
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-2, atomic_number=16, type_str="tipO", charge="0.00", sigma="3.16435", epsilon="0.16275", comment="TIP4P water O, long-range Coulombic solver"))
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-3, atomic_number=1, type_str="tipH", charge="+0.5242", sigma="0.0", epsilon="0.0", comment="TIP4P water H, long-range Coulombic solver"))
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-4, atomic_number=0, type_str="tipM", charge="-1.0484", sigma="1.0", epsilon="0.0", comment="TIP4P water M, long-range Coulombic solver"))
+# bonds.append(Bond(types=["tipO", "tipM"], k="900.00", eq="0.15", comment="TIP4P O-M"))
+# angles.append(Angle(types=["tipH", "tipO", "tipM"], k="50.00", eq="52.26", comment="TIP4P H-O-M"))
+
+# TIP5P water
+# user should be running this with fix rigid, so no flexible variant is provided;
+#   also, bonds shouldn't matter for this model,
+#   as it is kept rigid but "fix rigid" and not by bonded interactions
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-5, atomic_number=16, type_str="tipO", charge="0.00", sigma="3.0970", epsilon="0.1780", comment="TIP5P water O, long-range Coulombic solver"))
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-6, atomic_number=1, type_str="tipH", charge="+0.241", sigma="1.0", epsilon="0.0", comment="TIP5P water H, long-range Coulombic solver"))
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-7, atomic_number=0, type_str="tipL", charge="-0.241", sigma="1.0", epsilon="0.0", comment="TIP5P water L, long-range Coulombic solver"))
+# bonds.append(Bond(types=["tipO", "tipL"], k="900.00", eq="0.70", comment="TIP5P O-L"))
+# angles.append(Angle(types=["tipL5", "tipO", "tipL5"], k="50.00", eq="109.47", comment="TIP5P L-O-L"))
+# angles.append(Angle(types=["tipH", "tipO", "tipL5"], k="50.00", eq="110.6948", comment="TIP5P H-O-L"))
+
+# SPC and SPC/E (the same, just changes the charges on H and O...)
+# should be used with fix shake, LAMMPS doesn't mention a flexible variant
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-8, atomic_number=16, type_str="spcO", charge="-0.820", sigma="3.166", epsilon="0.1553", comment="SPC water O"))
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-10, atomic_number=16, type_str="spcO", charge="-0.8476", sigma="3.166", epsilon="0.1553", comment="SPC/E water O"))
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-9, atomic_number=1, type_str="spcH", charge="+0.410", sigma="0.0", epsilon="0.0", comment="SPC water H"))
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-11, atomic_number=1, type_str="spcH", charge="+0.4238", sigma="0.0", epsilon="0.0", comment="SPC/E water H"))
+bonds.append(Bond(types=["spcO", "spcH"], k="450.00", eq="1.000", comment="SPC-SPC/E O-H"))
+angles.append(Angle(types=["spcH", "spcO", "spcH"], k="55.00", eq="109.47", comment="SPC-SPC/E H-O-H"))
+
+# OPC
+# I saw users using this water model via the lj/long/tip4p/long pair_style,
+#   so as for TIP4P users need to provide O-E distance (0.1594) there and use fix shake.
+# parameters are taken from AmberTools2024
+#   where LJ distance parameter is provided as half r_min, not sigma, hence the conversion
+HALFRMIN2SIGMA = 2/(2**(1/6))
+sigma_opc_o = f"{1.777167268 * HALFRMIN2SIGMA:10.6f}".strip()
+sigma_opc_ep = f"{1 * HALFRMIN2SIGMA:10.6f}".strip()
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-12, atomic_number=16, type_str="opcO", charge="0.00", sigma=sigma_opc_o, epsilon="0.21280", comment="OPC water O"))
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-13, atomic_number=1, type_str="opcH", charge="+0.679142", sigma="0.0", epsilon="0.0", comment="OPC water H"))
+wat_atoms.append(Atom(type_id=STARTING_WAT_TYPE-14, atomic_number=0, type_str="opcE", charge="-1.358284", sigma=sigma_opc_ep, epsilon="0.0", comment="OPC water E"))
+bonds.append(Bond(types=["opcO", "opcH"], k="450.00", eq="0.8724", comment="OPC O-H"))
+angles.append(Angle(types=["opcH", "opcO", "opcH"], k="55.00", eq="103.6", comment="OPC H-O-H"))
+# bonds.append(Bond(types=["opcO", "opcE"], k="450.00", eq="0.1594", comment="OPC O-LP"))
+
+
+################################################################################################
+###### LET'S START WRITING STUFF
+##################### NOTE: i load and write the atom types concurrently,
+#####################       in this way I can keep the comment blocks from the original FF file
+################################################################################################
+atoms: list[Atom] = []
+with open(NEW_LT_FILENAME, "w") as f:
+    f.write(file_header)
+    f.write("  # NOTE2: I tried to maintain the same two-letter 'general' types as from\n")
+    f.write("  #  the original FF file. However, some changes had to be made to comply\n")
+    f.write("  #  to the inner functioning of moltemplate. Such changes were:\n  #\n")
+    for original, new in TYPE_CONVERSION_TUPLES:
+        f.write(f"  #    {original} --> {new}\n")
+
+    f.write("\n  # NOTE3: The original FF file had types for different water models,\n")
+    f.write("  #  but it was missing the relevant bonded interactions; therefore, I\n")
+    f.write("  #  skipped the water types from the original FF, and hardcoded some simple\n")
+    f.write("  #  water models, with the relevant bonded parameters\n")
+
+    f.write("\n  # NOTE4: Water TIP*/SPC* models parameters are taken from LAMMPS doc,\n")
+    f.write("  #  the user is invited to read the proper sections in the LAMMPS user manual\n")
+    f.write("  #  to properly understand how to setup a simulation with the desided model.\n")
+    f.write("  #  As for OPC, it seems it could be implemented in LAMMPS similarly to the\n")
+    f.write("  #   TIP4P model (where OM distance should be 0.1594 angstrom).\n")
+
+    f.write('\n\n  write_once("In Charges") {\n')
+    for line in lines[2:]:
+        if line.startswith("#    Add more charge and L-J parameters"):
+            break
+        if line.startswith("#"):
+            f.write(f"    {line}")
+        else:
+            atom = parse_atom_line(line)
+            if atom is not None:
+                atoms.append(atom)
+                f.write(f"    {atom.charge_line}")
+    for atom in wat_atoms:
+        f.write(f"    {atom.charge_line}")
+    f.write("  } # (end of atom partial charges)\n")
+    f.write('\n\n  write_once("Data Masses") {\n')
+    atoms += wat_atoms
+    for atom in atoms:
+        f.write(f"    {atom.mass_line}")
+    f.write("  } # (end of atom masses)\n")
+
+    f.write(file_equivalences_header)
+    for atom in atoms:
+        f.write(f"  {atom.repl_line}")
+
+    f.write(nb_header)
+    f.write('  write_once("In Settings") {\n')
+    for atom in atoms:
+        f.write(f"    {atom.nb_line}")
+    f.write("  } # (end of pair_coeffs)\n")
+
+    f.write("\n\n\n\n")
+    f.write("  # NOTE: all bonded interaction name can't have '*' or '?' characters, so in each\n")
+    f.write("  #   bonded sections such characters will be replaced with another character\n")
+    f.write("  #   that, at the time of writing, is not used for atom types (* -> £, ? -> €).\n\n")
+    f.write(bond_header)
+    f.write('\n  write_once("In Settings") {\n')
+    for bond in bonds:
+        if not bond.to_skip:
+            f.write(f"    {bond.coeff_line}")
+    f.write("  } # (end of bond_coeffs)\n")
+    f.write('\n  write_once("Data Bonds By Type") {\n')
+    for bond in bonds:
+        if not bond.to_skip:
+            f.write(f"    {bond.bytype_line}")
+    f.write("  } # (end of bonds by type)\n")
+
+    f.write(angle_header)
+    f.write('\n  write_once("In Settings") {\n')
+    for angle in angles:
+        if not angle.to_skip:
+            f.write(f"    {angle.coeff_line}")
+    f.write("  } # (end of angle_coeffs)\n")
+    f.write('\n  write_once("Data Angles By Type") {\n')
+    for angle in angles:
+        if not angle.to_skip:
+            f.write(f"    {angle.bytype_line}")
+    f.write("  } # (end of angles by type)\n")
+
+    f.write(dihedral_header)
+    f.write('\n  write_once("In Settings") {\n')
+    for dihedral in dihedrals:
+        if not dihedral.to_skip:
+            f.write(f"    {dihedral.coeff_line}")
+    f.write("  } # (end of dihedral_coeffs)\n")
+    f.write('\n  write_once("Data Dihedrals By Type") {\n')
+    for dihedral in dihedrals:
+        if not dihedral.to_skip:
+            f.write(f"    {dihedral.bytype_line}")
+    f.write("  } # (end of dihedrals by type)\n")
+
+    f.write(improper_header)
+    f.write('\n  write_once("In Settings") {\n')
+    for improper in impropers:
+        if not improper.to_skip:
+            f.write(f"    {improper.coeff_line}")
+    f.write("  } # (end of improper_coeffs)\n")
+    f.write('\n  write_once("Data Impropers By Type (opls_imp.py)") {\n')
+    for improper in impropers:
+        if not improper.to_skip:
+            f.write(f"    {improper.bytype_line}")
+    f.write("  } # (end of impropers by type)\n")
+
+    f.write(closing_stuff)
+    f.write("}\n")

--- a/moltemplate/force_fields/convert_OPLSAA_to_LT/oplsaa2lt_classes.py
+++ b/moltemplate/force_fields/convert_OPLSAA_to_LT/oplsaa2lt_classes.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+
+from abc import ABC, abstractmethod
+from oplsaa2lt_utils import data_from_atm_num
+
+
+class Atom:
+    """
+    An Atom object, representing a single OPLSAA atom type,
+    based on the paper Jorgensen_et_al-2024-The_Journal_of_Physical_Chemistry_B.
+    NB: some values like charge-sigma-epsilon are kept as strings, to assure
+    exactly the same values from the origianl FF file are taken
+
+    Args and Attributes:
+        type_id (int): the integer type ID from OPLSAA
+        atomic_number (int): the atomic number of the atom
+        type_str (str): the string representation of the atom type "subclass"
+        charge (str): the charge of the atom
+        sigma (str): the LJ-sigma value for the atom
+        epsilon (str): the LJ-epsilon value for the atom
+        comment (str): a comment associated with the atom (usually read from the original FF file)
+
+    Attributes:
+        element (str): the element of the atom (inferred from atomic_number)
+        mass (str): the mass of the atom (inferred from atomic_number)
+
+    Returns:
+        an instance of the Atom class with the provided parameters
+    """
+    def __init__(self,
+                 type_id: int,
+                 atomic_number: int,
+                 type_str: str,
+                 charge: str,
+                 sigma: str,
+                 epsilon: str,
+                 comment: str):
+
+        self.type_id = type_id
+        self.atomic_number = atomic_number
+        self.type_str = type_str
+        self.charge = charge
+        self.sigma = sigma
+        self.epsilon = epsilon
+        self.bonded_type = type_str
+
+        # NOTE: taking care of LP, which have atomic number 02, but it's not He...
+        if self.type_str == "LP":
+            self.atomic_number = 0
+
+        self.element: str = data_from_atm_num[atomic_number]['element']
+        self.mass: str = data_from_atm_num[atomic_number]['mass']
+
+        self.comment = f"{self.element:2s} | {comment}"
+
+    @property
+    def type_long(self) -> str:
+        """
+        This property returns a string representing the full type identifier for the atom.
+        It includes the atom's type ID, followed by the bonded type for each type of bonded
+        interaction (bond, angle, dihedral, improper), underscore separated.
+        """
+        l = f"{self.type_id}"
+        l += f"_b{self.bonded_type}"
+        l += f"_a{self.bonded_type}"
+        l += f"_d{self.bonded_type}"
+        l += f"_i{self.bonded_type}"
+        return l
+
+    @property
+    def charge_line(self) -> str:
+        return f"set type @atom:{self.type_id:<4d} charge {self.charge:>10s} # {self.comment}\n"
+
+    @property
+    def mass_line(self) -> str:
+        return f"@atom:{self.type_id:<4d} {self.mass:<s}\n"
+
+    @property
+    def repl_line(self) -> str:
+        return f"replace{{ @atom:{self.type_id:<4d} @atom:{self.type_long} }}\n"
+
+    @property
+    def nb_line(self) -> str:
+        l = f"pair_coeff @atom:{self.type_long} @atom:{self.type_long}"
+        l += f" {self.epsilon} {self.sigma}\n"
+        return l
+
+
+class BondedInteraction(ABC):
+    """A base class for bonded interactions, providing common functionalities"""
+
+    kind: str
+
+    def __init__(self, types: list[str], comment: str):
+        self.types = [ty.strip() for ty in types]
+        self.comment = comment
+        self.to_comment = False
+        self.to_skip = False
+
+    @property
+    def ty1(self) -> str:
+        return self.types[0]
+
+    @property
+    def ty2(self) -> str:
+        return self.types[1]
+
+    @property
+    def ty3(self) -> str:
+        return self.types[2]
+
+    @property
+    def ty4(self) -> str:
+        return self.types[3]
+
+    @property
+    def num_types(self) -> int:
+        return len(self.types)
+
+    @property
+    def typename(self) -> str:
+        """ This property returns a string with the name of the bonded interaction,
+        composed by the names of the "base" atom types that form such interaction,
+        separated by an underscore.
+
+        NOTE: the bonded interaction name can't have "*" or "?" characters,
+        so here such characters will be replaced with another character that,
+        at the time of writing, is not used for atom types.
+        """
+        renamed_types = []
+        for ty in self.types:
+            renamed_types.append(ty.replace("*", "£").replace("?", "€"))
+        return "_".join(renamed_types)
+
+    @property
+    def _coeff_line_base(self):
+        return f"{type(self).kind}_coeff @{type(self).kind}:{self.typename}"
+
+    @property
+    @abstractmethod
+    def coeff_line(self) -> str:
+        pass
+
+    @property
+    @abstractmethod
+    def bytype_line(self) -> str:
+        pass
+
+    @property
+    def sort_key(self):
+        """ This property returns a tuple that can be used to sort the interactions
+        in a way that the more general interactions (the ones with * and ?)
+        are placed at the beginning of the section."""
+
+        def prioritize(ty):
+            priority = lowest_priority
+            if ty == "*":
+                priority = 0
+            elif ty == "?":
+                priority = 1
+            elif ty == "**":
+                priority = 2
+            elif ty == "??":
+                priority = 3
+            elif ty.startswith("*"):
+                priority = 4
+            elif ty.startswith("?"):
+                priority = 5
+            elif ty.endswith("*"):
+                priority = 6
+            elif ty.endswith("?"):
+                priority = 7
+            return priority
+
+        lowest_priority = 8
+        priority_tuple = (
+            prioritize(self.ty1),
+            prioritize(self.ty2),
+            prioritize(self.ty3) if self.num_types >= 3 else lowest_priority,
+            prioritize(self.ty4) if self.num_types >= 4 else lowest_priority
+            )
+        return priority_tuple
+
+    @property
+    def _check_if_comment(self) -> str:
+        if self.typename == "HC_CT_CT_C(O)" or self.to_comment:
+            return "#"
+        return ""
+
+
+class Bond(BondedInteraction):
+    kind = "bond"
+    def __init__(self, types: list[str], k: str, eq: str, comment: str):
+        super().__init__(types, comment)
+        if len(self.types) != 2:
+            raise ValueError(f"interaction of type '{type(self).kind}' must have 2 types...")
+        self.k = k
+        self.eq = eq
+        self.comment = comment
+
+    @property
+    def bytype_line(self) -> str:
+        l = f"{self._check_if_comment}"
+        l += f"@{type(self).kind}:{self.typename}"
+        l += f" @atom:*_b{self.ty1}_a*_d*_i*"
+        l += f" @atom:*_b{self.ty2}_a*_d*_i*\n"
+        return l
+
+    @property
+    def coeff_line(self) -> str:
+        l = f"{self._check_if_comment}"
+        l += f"{self._coeff_line_base} {self.k} {self.eq} # {self.comment}\n"
+        return l
+
+
+class Angle(BondedInteraction):
+    kind = "angle"
+    def __init__(self, types: list[str], k: str, eq: str, comment: str):
+        super().__init__(types, comment)
+        if len(self.types) != 3:
+            raise ValueError(f"interaction of type '{type(self).kind}' must have 3 types...")
+        self.k = k
+        self.eq = eq
+        self.comment = comment
+
+    @property
+    def bytype_line(self) -> str:
+        l = f"{self._check_if_comment}"
+        l += f"@{type(self).kind}:{self.typename}"
+        l += f" @atom:*_b*_a{self.ty1}_d*_i*"
+        l += f" @atom:*_b*_a{self.ty2}_d*_i*"
+        l += f" @atom:*_b*_a{self.ty3}_d*_i*\n"
+        return l
+
+    @property
+    def coeff_line(self) -> str:
+        l = f"{self._check_if_comment}"
+        l += f"{self._coeff_line_base} {self.k} {self.eq} # {self.comment}\n"
+        return l
+
+
+class Dihedral(BondedInteraction):
+    kind = "dihedral"
+    def __init__(self, types: list[str], v1, v2, v3, v4, comment: str):
+        super().__init__(types, comment)
+        if len(self.types) != 4:
+            raise ValueError(f"interaction of type '{type(self).kind}' must have 4 types...")
+        self.v1, self.v2, self.v3, self.v4 = v1, v2, v3, v4
+        self.comment = comment
+
+    @property
+    def bytype_line(self) -> str:
+        l = f"{self._check_if_comment}"
+        l += f"@{type(self).kind}:{self.typename}"
+        l += f" @atom:*_b*_a*_d{self.ty1}_i*"
+        l += f" @atom:*_b*_a*_d{self.ty2}_i*"
+        l += f" @atom:*_b*_a*_d{self.ty3}_i*"
+        l += f" @atom:*_b*_a*_d{self.ty4}_i*\n"
+        return l
+
+    @property
+    def coeff_line(self) -> str:
+        l = f"{self._check_if_comment}"
+        l += f"{self._coeff_line_base} {self.v1} {self.v2} {self.v3} {self.v4}"
+        l += f" # {self.comment} \n"
+        return l
+
+
+class Improper(BondedInteraction):
+    kind = "improper"
+    def __init__(self, types: list[str], v1, v2, v3, v4, comment: str):
+        super().__init__(types, comment)
+        if len(self.types) != 4:
+            raise ValueError(f"interaction of type '{type(self).kind}' must have 4 types...")
+        self.v1, self.v2, self.v3, self.v4 = v1, v2, v3, v4
+        self.comment = comment
+
+        # replacing every X/Y/Z with "*", I don't know if that's the correct approach,
+        # as if this was the intended behaviour I think in the FF file they would have used
+        # "*", as they did in the dihedrals sections...
+        for i, ty in enumerate(self.types):
+            if ty in ("X", "Y", "Z"):
+                self.types[i] = "*"
+
+    @property
+    def bytype_line(self) -> str:
+        l = f"{self._check_if_comment}"
+        l += f"@{type(self).kind}:{self.typename}"
+        l += f" @atom:*_b*_a*_d*_i{self.ty1}"
+        l += f" @atom:*_b*_a*_d*_i{self.ty2}"
+        l += f" @atom:*_b*_a*_d*_i{self.ty3}"
+        l += f" @atom:*_b*_a*_d*_i{self.ty4}\n"
+        return l
+
+    @property
+    def coeff_line(self) -> str:
+        l = f"{self._check_if_comment}"
+        l += f"{self._coeff_line_base} {float(self.v2)/2:.4f} -1 2 # {self.comment}\n"
+        return l

--- a/moltemplate/force_fields/convert_OPLSAA_to_LT/oplsaa2lt_utils.py
+++ b/moltemplate/force_fields/convert_OPLSAA_to_LT/oplsaa2lt_utils.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+
+file_header = """
+# This file contains OPLSAA parameters and rules for creating angle, dihedral,
+# and improper interactions according to OPLSAA conventions, taken from
+# "Jorgensen_et_al-2024-The_Journal_of_Physical_Chemistry_B.sup-1"
+#
+# USAGE: You can create molecules using this force-field this way:
+#
+# MyMolecule inherits OPLSAA {
+#  # atom-id  mol-id atom-type charge    X        Y        Z
+#  write('Data Atoms') {
+#    $atom:C1  $mol @atom:88  0.00  -0.6695    0.000000  0.000000
+#    $atom:H11 $mol @atom:89  0.00  -1.234217 -0.854458  0.000000
+#         :              :     :      :         :         :
+#   }
+# }
+#
+# You can omit the atom charge in your molecule definition.
+# (Partial charges will be assigned later according to the force field rules.)
+# Responsibility for choosing the atom types (eg "@atom:88", "@atom:89") falls
+# on the user.  You must select the type of each atom in the molecule carefully
+# by looking at the description in the "In Charges" section of this file
+# (see below), and looking for a reasonable match. If your simulation is
+# non-neutral, or moltemplate complains that you have missing bond, angle, or
+# dihedral types, this means at least one of your atom types is incorrect.
+
+
+OPLSAA {
+
+  # Below we will use lammps "set" command to assign atom charges
+  # by atom type.  https://docs.lammps.org/set.html
+
+  # NOTE1: the commented blocks that you'll find are copied as found in the 
+  #   original FF-file, so they don't respect the format/syntax used here
+  #   (I thought some of them could be useful anyway, so I kept them here)
+
+"""
+
+file_equivalences_header = """
+
+  # ---------- EQUIVALENCE CATEGORIES for bonded interaction lookup ----------
+  #   Each type of atom has a separate ID used for looking up bond parameters
+  #   and a separate ID for looking up 3-body angle interaction parameters
+  #   and a separate ID for looking up 4-body dihedral interaction parameters
+  #   and a separate ID for looking up 4-body improper interaction parameters
+  #   The complete @atom type name includes ALL of these ID numbers.  There's
+  #   no need to force the end-user to type the complete name of each atom.
+  #   The "replace" command used below informs moltemplate that the short
+  #   @atom names we have been using above are equivalent to the complete
+  #   @atom names used below:
+
+"""
+
+nb_header = """
+
+  # --------------- Non-Bonded interactions: ---------------------
+  # https://docs.lammps.org/pair_lj.html
+  # Syntax:
+  # pair_coeff    AtomType1    AtomType2   parameters...
+
+"""
+
+bond_header = """
+
+  # ------- Bond Interactions: -------
+  # https://docs.lammps.org/bond_harmonic.html
+  # Syntax:  
+  # bond_coeff BondTypeName  parameters...
+
+"""
+
+angle_header = """
+
+  # ------- Angle Interactions: -------
+  # https://docs.lammps.org/angle_harmonic.html
+  # Syntax:  
+  # angle_coeff AngleTypeName  parameters...
+
+"""
+
+dihedral_header = """
+
+  # ----------- Dihedral Interactions: ------------
+  # https://docs.lammps.org/dihedral_opls.html
+  # Syntax:
+  # dihedral_coeff DihedralTypeName  parameters...
+
+"""
+
+improper_header = """
+
+  # ---------- Improper Interactions: ----------
+  # https://docs.lammps.org/dihedral_opls.html
+  # https://docs.lammps.org/improper_cvff.html
+  # https://docs.lammps.org/improper_harmonic.html
+  # NOTE: impropers are a WIP, currently implemented as improper_cvff
+  # Syntax:
+  # improper_coeff ImproperTypeName  parameters
+
+"""
+
+closing_stuff = """
+
+  # LAMMPS supports many different kinds of bonded and non-bonded
+  # interactions which can be selected at run time.  Eventually
+  # we must inform LAMMPS which of them we will need.  We specify
+  # this in the "In Init" section: 
+
+  write_once("In Init") {
+    units real
+    atom_style full
+    bond_style harmonic
+    angle_style harmonic
+    dihedral_style opls
+    improper_style cvff
+    # NOTE: in the original oplsaa.lt file the pair style was
+    #   lj/cut/coul/long 11.0 11.0
+    # but with an accompanying note stating that OPLSAA/M (2015) 
+    # uses a different pair style, the one used here
+    # (as I trusted the original author)
+    pair_style lj/charmm/coul/long 9.0 11.0
+    pair_modify mix geometric
+    special_bonds lj/coul 0.0 0.0 0.5
+    kspace_style pppm 0.0001
+  } #end of init parameters
+
+"""
+
+data_from_atm_num = {
+    0: {"element": "XX", "mass": "0.00000000000000001"},
+    1: {"element": "H", "mass": "1.008"},
+    2: {"element": "He", "mass": "4.003"},
+    3: {"element": "Li", "mass": "6.941"},
+    4: {"element": "Be", "mass": "9.012"},
+    5: {"element": "B", "mass": "10.811"},
+    6: {"element": "C", "mass": "12.011"},
+    7: {"element": "N", "mass": "14.007"},
+    8: {"element": "O", "mass": "15.999"},
+    9: {"element": "F", "mass": "18.998"},
+    10: {"element": "Ne", "mass": "20.179"},
+    11: {"element": "Na", "mass": "22.990"},
+    12: {"element": "Mg", "mass": "24.305"},
+    13: {"element": "Al", "mass": "26.982"},
+    14: {"element": "Si", "mass": "28.086"},
+    15: {"element": "P", "mass": "30.974"},
+    16: {"element": "S", "mass": "32.065"},
+    17: {"element": "Cl", "mass": "35.453"},
+    18: {"element": "Ar", "mass": "39.948"},
+    19: {"element": "K", "mass": "39.098"},
+    20: {"element": "Ca", "mass": "40.078"},
+    30: {"element": "Zn", "mass": "65.377"},
+    35: {"element": "Br", "mass": "79.904"},
+    36: {"element": "Kr", "mass": "83.798"},
+    37: {"element": "Rb", "mass": "85.468"},
+    38: {"element": "Sr", "mass": "87.620"},
+    53: {"element": "I", "mass": "126.905"},
+    54: {"element": "Xe", "mass": "131.293"},
+    55: {"element": "Cs", "mass": "132.905"},
+    56: {"element": "Ba", "mass": "137.327"},
+    57: {"element": "La", "mass": "138.905"},
+    60: {"element": "Nd", "mass": "144.242"},
+    63: {"element": "Eu", "mass": "151.964"},
+    64: {"element": "Gd", "mass": "157.25"},
+    70: {"element": "Yb", "mass": "173.04"},
+    89: {"element": "Ac", "mass": "227.000"},
+    90: {"element": "Th", "mass": "232.038"},
+    92: {"element": "U", "mass": "238.029"},
+    95: {"element": "Am", "mass": "243.000"},
+    99: {"element": "DM", "mass": "1.000"},
+}


### PR DESCRIPTION
Hello everyone,

I'm creating this PR to address issue #104. 

I should have addressed all the requests made in the issue, I also refactored a little bit the code.

Below, I'm reporting some of the considerations we made in the issue, with some comments.

# Duplicated interactions

Regarding the duplicated interactions, the observations from the previous files and the current implementation are summarized here.

**old PRM from TINKER**

Duplicated interactions are commented out (and are found only in the dihedrals section). There is a note about it at the beginning of the "Torsional Parameters" section

**old LT, oplsaa.lt**

It just missed the duplicated dihedral interactions, because they were commented out in the original PRM file, and so they were skipped by the converter

**NEW oplsaa2023 from paper SI (similar to the files provided with BOSS)**

Some duplicates are found in bonds/angles/dihedrals, many of which have the same parameters (particularly in the angles section). Here are some examples of lines with duplicated entries with different parameters:

    CW-C= 481.       1.454        JT-R 2014/04 2-vinyl furans
    CW-C= 549.       1.365
---
    CV-CW-NA     70.       106.3    wlj   "     "  imidazole
    CV-CW-NA     70.       103.6    wlj  6/13               
---
    003   0.850    -0.200     0.200     0.0        CT-CT-CT-CT     hydrocarbon OPLS/2020                
    004   1.100    -0.200     0.200     0.0        CT-CT-CT-CT     butane only OPLS/2020                
    :
    005   2.0      -0.20     0.0       0.0         CT-CT-CT-OH     alcohols         OPLS/2020           
    :
    007  -1.552     0.0      0.000     0.0         CT-CT-CT-OH     polyols  AA
    :
    :
    223   0.0       2.17      0.0       0.0        CA-C!-CW-NA     biphenyl-like                        
    :
    :
    431   0.0       2.0       0.0       0.0        CA-C!-CW-NA     biaryl_7                             

an important note is that the comment is not always clear "as it is", as often it "relies" on the comment(s) above. That's a problem when I convert the file, as reordering the interactions I miss such information (this is clear in the second angle example below...)

**NEW oplsaa2023 LT**
    
Duplicates with the same parameters are just skipped, while "real" duplicates are commented out. The cool thing is that they should always appear near each other in this file, and that was not true in the original file, so one could have easily missed some interaction.
As explained above, the comment is not always helpful in determining which parameters to apply, but it is what it is I think... It's relatively easy to go back to the original FF file to check the comment in its context, having maintained the type-names... 

    bond_coeff @bond:CW_C= 481. 1.454     # JT-R 2014/04 2-vinyl furans
    #bond_coeff @bond:CW_C= 549. 1.365     # 
---
    angle_coeff @angle:CV_CW_NA 70. 106.3    # wlj " " imidazole
    #angle_coeff @angle:CV_CW_NA 70. 103.6    # wlj 6/13
---
    dihedral_coeff @dihedral:CA_C!_CW_NA 0.0 2.17 0.0 0.0        # biphenyl-like
    #dihedral_coeff @dihedral:CA_C!_CW_NA 0.0 2.0 0.0 0.0         # biaryl_7 
    :
    dihedral_coeff @dihedral:CT_CT_CT_CT 0.850 -0.200 0.200 0.0  # hydrocarbon OPLS/2020 
    #dihedral_coeff @dihedral:CT_CT_CT_CT 1.100 -0.200 0.200 0.0  # butane only OPLS/2020 
    :
    dihedral_coeff @dihedral:CT_CT_CT_OH 2.0 -0.20 0.0 0.0       # alcohols OPLS/2020 
    #dihedral_coeff @dihedral:CT_CT_CT_OH -1.552 0.0 0.000 0.0    # polyols  AA

___________________


# Waters

**old PRM from TINKER (inherited by old oplsaa.lt)**

has different atom types for different water models; has also flexible variants

    31 OW TIP3-4-P      31-32 & 39-40           k=600.00     r=0.9572
    32 HW TIP3-4-P      32-31-32 & 40-39-40      k=75.00     a=104.52
    39 OW TIP5P
    40 HW TIP5P

    33  M 4P            32-31-33      k=50.00    a=52.26
                        31-33        k=900.00     r=0.1500

    41 LP TIP5P         39-41        900.00     0.7000
                        41-39-41      50.00     109.47
                        40-39-41      50.00     110.6948

    42 OW SPC           42-43        600.00     1.0000
    43 HW SPC           43-42-43      75.00     109.47

The non-bonded parameters seem Wikipedia-correct, but they are not the parameters LAMMPS suggests when one uses PPPM/Ewald, as we are suggesting to the user (see below).
It seems also correct in the O-H and H-O-H parameters, I don't understand why there are bonded interactions with the LP, as those in lammps are treated directly by the pair_style lj/cut/tip4p/cut for TIP4P, while for TIP5P model just the angle L-O-L and distance O-L should be used if I understand the documentation correctly.


**NEW oplsaa2023 from paper SI (similar to the files provided with BOSS)**

Has just one single OW-HW parameter and OW-LP parameter (in the comment it reports they are for for TIP4F water model), and the same is true for HW-OW-HW and OW-LP-HW... The strange thing is that in the atom type definition section, it has explicitly TIP3-4-5P, their flexible variants, and also SPC types... unfortunately, the relative bonded parameters are completely missing :-)


**NEW oplsaa2023.lt**

I propose to completely skip reading the water-related atom types definitions and bonded definitions (just skipping whenever "water" is found in the comment), and just add by hand the relevant parameters, in this way, we can have direct control over the parameters... the only thing to keep in mind is that we have to identify "two-letter" type definitions that don't clash with the ones already in the FF file... I'm using "three-letter" types, that should do the trick...

The parameters I added are taken from the LAMMPS documentation, as we are suggesting using PPPM and LAMMPS indicates different parameters than the ones in the old oplsaa.lt if one wants to use PPPM or Ewald. See the script for more precise comments on each parameter (I also added a note to the user to read the proper LAMMPS documentation when selecting the water model).
It would be great to also introduce the OPC water model, but I don't really know how if I correctly implemented it here, I based my implementation on a thread in MATSCI [https://matsci.org/t/use-opc-water-model/36419](url)

Please have a careful look at the water parameters (particularly charges and LJ parameters), as I may have made mistakes copying stuff around from Wikipedia/documentation and all forcefield files :-)

___________________


# Impropers

They are still a work in progress, I just added the missing `(opls_imp.py)`, but I didn't check if they are correctly detected and applied.
