### PR TITLE
Add bonded_type information in the comment of each atom in the charges section

### DIFF
--- a/moltemplate/force_fields/convert_OPLSAA_to_LT/oplsaa2lt_classes.py
+++ b/moltemplate/force_fields/convert_OPLSAA_to_LT/oplsaa2lt_classes.py
@@ -44,14 +44,14 @@ class Atom:
         self.epsilon = epsilon
         self.bonded_type = type_str
 
-        # NOTE: taking care of LP, which have atomic number 02, but it's not He...
+        # NOTE: taking care of LP, which has atomic number 02, but it's not He...
         if self.type_str == "LP":
             self.atomic_number = 0
 
         self.element: str = data_from_atm_num[atomic_number]['element']
         self.mass: str = data_from_atm_num[atomic_number]['mass']
 
-        self.comment = f"{self.element:2s} | {comment}"
+        self.comment = f"{self.element:2s} - {self.bonded_type:4s} | {comment}"
 
     @property
     def type_long(self) -> str:


### PR DESCRIPTION
Hi!
Thank you @jewettaij for the updates and for all the work done!

I'm making this small pull request as I think it could be beneficial for the user to have also the bonded_type string visible in the comment line of the charges section (where one has to select the proper type), as it can help to understand which bonded interactions will be selected down the line!

The only drawback I forsee is if some type will have different bonded_type for bond/angle/dihedral, but that's never the case for now, I think.

